### PR TITLE
Handle index.php login endpoint

### DIFF
--- a/YBS_CONTROL.py
+++ b/YBS_CONTROL.py
@@ -4,8 +4,10 @@ import threading
 import requests
 from bs4 import BeautifulSoup
 import time
+import os
 
-LOGIN_URL = "https://www.ybsnow.com/login.php"
+# Default login endpoint discovered from the HTML form
+LOGIN_URL = "https://www.ybsnow.com/index.php"
 ORDERS_URL = "https://www.ybsnow.com/manage.html"
 
 class OrderScraperApp:
@@ -14,10 +16,19 @@ class OrderScraperApp:
         self.root.title("Order Scraper")
 
         self.session = requests.Session()
+        self.session.headers.update({
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/120.0 Safari/537.36"
+            )
+        })
         self.logged_in = False
 
         self.username_var = ctk.StringVar()
         self.password_var = ctk.StringVar()
+        self.login_url_var = ctk.StringVar(value=LOGIN_URL)
+        self.orders_url_var = ctk.StringVar(value=ORDERS_URL)
 
         # Tabs
         self.tab_control = ctk.CTkTabview(root)
@@ -26,11 +37,15 @@ class OrderScraperApp:
         self.tab_control.pack(expand=1, fill="both")
 
         # Settings Tab
-        ctk.CTkLabel(self.settings_tab, text="Username:").grid(row=0, column=0, padx=5, pady=5)
+        ctk.CTkLabel(self.settings_tab, text="Email:").grid(row=0, column=0, padx=5, pady=5)
         ctk.CTkEntry(self.settings_tab, textvariable=self.username_var).grid(row=0, column=1, padx=5, pady=5)
         ctk.CTkLabel(self.settings_tab, text="Password:").grid(row=1, column=0, padx=5, pady=5)
         ctk.CTkEntry(self.settings_tab, textvariable=self.password_var, show='*').grid(row=1, column=1, padx=5, pady=5)
-        ctk.CTkButton(self.settings_tab, text="Login", command=self.login).grid(row=2, column=0, columnspan=2, pady=10)
+        ctk.CTkLabel(self.settings_tab, text="Login URL:").grid(row=2, column=0, padx=5, pady=5)
+        ctk.CTkEntry(self.settings_tab, textvariable=self.login_url_var).grid(row=2, column=1, padx=5, pady=5)
+        ctk.CTkLabel(self.settings_tab, text="Orders URL:").grid(row=3, column=0, padx=5, pady=5)
+        ctk.CTkEntry(self.settings_tab, textvariable=self.orders_url_var).grid(row=3, column=1, padx=5, pady=5)
+        ctk.CTkButton(self.settings_tab, text="Login", command=self.login).grid(row=4, column=0, columnspan=2, pady=10)
 
         # Orders Tab
         self.table_frame = ctk.CTkFrame(self.orders_tab)
@@ -60,9 +75,17 @@ class OrderScraperApp:
     def login(self):
         username = self.username_var.get()
         password = self.password_var.get()
-        data = {'username': username, 'password': password}
-        resp = self.session.post(LOGIN_URL, data=data)
-        if "logout" in resp.text.lower() or "manage.html" in resp.text.lower():
+        # The login form uses 'email' and includes a hidden 'action=signin'
+        data = {'email': username, 'password': password, 'action': 'signin'}
+        login_url = self.login_url_var.get() or LOGIN_URL
+        try:
+            resp = self.session.post(login_url, data=data, timeout=15)
+        except requests.RequestException as e:
+            self.logged_in = False
+            messagebox.showerror("Login", f"Request failed: {e}")
+            return
+        orders_page = os.path.basename(self.orders_url_var.get() or ORDERS_URL).lower()
+        if "logout" in resp.text.lower() or orders_page in resp.text.lower():
             self.logged_in = True
             messagebox.showinfo("Login", "Login successful!")
         else:
@@ -74,7 +97,12 @@ class OrderScraperApp:
         if not self.logged_in:
             messagebox.showerror("Error", "Not logged in!")
             return
-        resp = self.session.get(ORDERS_URL)
+        orders_url = self.orders_url_var.get() or ORDERS_URL
+        try:
+            resp = self.session.get(orders_url, timeout=15)
+        except requests.RequestException as e:
+            messagebox.showerror("Orders", f"Request failed: {e}")
+            return
         soup = BeautifulSoup(resp.text, 'html.parser')
         tbody = soup.find('tbody', id='table')
         self.orders_tree.delete(*self.orders_tree.get_children())

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ A simple Python GUI tool to log in to ybsnow.com, persist the session, and scrap
 Features
 Easy-to-use CustomTkinter GUI with Settings and Orders tabs in a dark teal theme
 
-Secure login (username & password, stored only for session)
+Secure login (email & password, stored only for session)
 
 Retrieves tabular order information from the orders page
 
@@ -13,6 +13,10 @@ Refresh orders with a single click
 Automatic session relogin every 2 hours
 
 Easily extendable for export (CSV, Excel, etc.)
+
+Specify custom Login and Orders URLs (handles .php or .html pages)
+Sends a browser User-Agent header for compatibility
+Default login posts to index.php using email and password fields
 
 Requirements
 Python 3.8+
@@ -40,7 +44,9 @@ Login
 
 Go to the “Settings” tab
 
-Enter your YBS username and password, then click Login
+Enter your YBS email and password.
+Optional: adjust the Login URL or Orders URL if your site uses different
+endpoints, then click Login
 
 View Orders
 
@@ -65,6 +71,7 @@ Error Handling: Modify login or table parsing logic as site changes.
 
 Troubleshooting
 If login fails, double-check your credentials.
+If the request fails immediately, ensure your network or proxy allows access to the site. Connection issues will now appear in the login popup.
 
 If the table isn’t loading, the site structure may have changed (contact the maintainer for updates).
 


### PR DESCRIPTION
## Summary
- default login URL is index.php and expects `email`+`password`
- add hidden `action=signin` when logging in
- label username field as Email
- document index.php login details

## Testing
- `python -m py_compile YBS_CONTROL.py`


------
https://chatgpt.com/codex/tasks/task_e_688ab519a528832d9461804af5747d21