### PR TITLE
Implement lead time report generator

### DIFF
--- a/lead_time_report.py
+++ b/lead_time_report.py
@@ -1,0 +1,77 @@
+import csv
+from datetime import datetime, timedelta
+from collections import defaultdict
+import argparse
+
+DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Generate lead time report from CSV data")
+    parser.add_argument("csv_file", help="Path to job timeline CSV")
+    parser.add_argument("--start", help="Start date (YYYY-MM-DD)")
+    parser.add_argument("--end", help="End date (YYYY-MM-DD)")
+    parser.add_argument("--output", default="lead_time_report.csv", help="Output CSV path")
+    return parser.parse_args()
+
+
+def load_rows(path):
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            yield {
+                "job_number": row.get("job_number"),
+                "step": row.get("step"),
+                "time_in": datetime.strptime(row.get("time_in"), DATE_FORMAT),
+                "time_out": datetime.strptime(row.get("time_out"), DATE_FORMAT),
+            }
+
+
+def business_hours_delta(start, end):
+    total = timedelta(0)
+    current = start
+    while current < end:
+        next_day = (current + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+        working_end = min(next_day, end)
+        # skip weekends
+        if current.weekday() < 5:
+            total += working_end - current
+        current = next_day
+    return total
+
+
+def compute_lead_times(rows, start_date=None, end_date=None):
+    results = defaultdict(list)
+    for row in rows:
+        if start_date and row["time_in"] < start_date:
+            continue
+        if end_date and row["time_out"] > end_date:
+            continue
+        delta = business_hours_delta(row["time_in"], row["time_out"])
+        hours = delta.total_seconds() / 3600.0
+        results[row["job_number"]].append({"step": row["step"], "hours": hours})
+    return results
+
+
+def write_report(results, path):
+    with open(path, "w", newline="") as f:
+        fieldnames = ["job_number", "step", "hours_in_queue"]
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for job, steps in results.items():
+            for step in steps:
+                writer.writerow({"job_number": job, "step": step["step"], "hours_in_queue": f"{step['hours']:.2f}"})
+
+
+def main():
+    args = parse_args()
+    start_date = datetime.strptime(args.start, "%Y-%m-%d") if args.start else None
+    end_date = datetime.strptime(args.end, "%Y-%m-%d") if args.end else None
+    rows = list(load_rows(args.csv_file))
+    results = compute_lead_times(rows, start_date, end_date)
+    write_report(results, args.output)
+    print(f"Report written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/manage_html_report.py
+++ b/manage_html_report.py
@@ -1,0 +1,95 @@
+import csv
+import re
+from datetime import datetime, timedelta
+from collections import defaultdict
+from bs4 import BeautifulSoup
+import argparse
+
+HTML_DATE_FORMAT = "%m/%d/%y %H:%M"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Generate lead time report from manage.html")
+    parser.add_argument("html_file", help="Path to manage.html")
+    parser.add_argument("--output", default="lead_time_report.csv", help="Output CSV path")
+    return parser.parse_args()
+
+
+def business_hours_delta(start, end):
+    total = timedelta(0)
+    current = start
+    while current < end:
+        next_day = (current + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+        working_end = min(next_day, end)
+        if current.weekday() < 5:
+            total += working_end - current
+        current = next_day
+    return total
+
+
+def parse_manage_html(path):
+    with open(path, "r", encoding="utf-8") as f:
+        soup = BeautifulSoup(f, "html.parser")
+    jobs = {}
+    for tr in soup.select("tbody#table tr"):
+        move_td = tr.find("td", class_="move")
+        if not move_td:
+            continue
+        job_text = move_td.get_text(strip=True)
+        parts = job_text.split()
+        job_number = parts[-1] if parts else None
+        if not job_number:
+            continue
+        steps = []
+        for li in tr.select("ul.workplaces li"):
+            step_p = li.find("p")
+            if not step_p:
+                continue
+            step_name = re.sub(r"^\d+", "", step_p.get_text(strip=True))
+            time_p = li.find("p", class_="np")
+            timestamp = None
+            if time_p:
+                text = time_p.get_text(strip=True).replace("\xa0", "").strip()
+                if text:
+                    try:
+                        timestamp = datetime.strptime(text, HTML_DATE_FORMAT)
+                    except ValueError:
+                        pass
+            steps.append((step_name.strip(), timestamp))
+        jobs[job_number] = steps
+    return jobs
+
+
+def compute_lead_times(jobs):
+    results = defaultdict(list)
+    for job, steps in jobs.items():
+        for i in range(len(steps) - 1):
+            name, start = steps[i]
+            next_name, end = steps[i + 1]
+            if start and end:
+                delta = business_hours_delta(start, end)
+                hours = delta.total_seconds() / 3600.0
+                results[job].append({"step": next_name, "hours": hours})
+    return results
+
+
+def write_report(results, path):
+    with open(path, "w", newline="") as f:
+        fieldnames = ["job_number", "step", "hours_in_queue"]
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for job, steps in results.items():
+            for step in steps:
+                writer.writerow({"job_number": job, "step": step["step"], "hours_in_queue": f"{step['hours']:.2f}"})
+
+
+def main():
+    args = parse_args()
+    jobs = parse_manage_html(args.html_file)
+    results = compute_lead_times(jobs)
+    write_report(results, args.output)
+    print(f"Report written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/readme.md
+++ b/readme.md
@@ -79,3 +79,13 @@ This project is for educational/internal automation purposes only. Do not distri
 
 Need a feature or help?
 Open an issue or contact Valis.
+
+Lead Time Report
+----------------
+The `lead_time_report.py` script generates a CSV report showing how long jobs spend in each workstation queue. The input CSV must contain the columns `job_number`, `step`, `time_in`, and `time_out` where the timestamps are in `YYYY-MM-DD HH:MM:SS` format. Usage:
+
+```bash
+python lead_time_report.py data.csv --start 2024-01-01 --end 2024-01-31 --output report.csv
+```
+
+The script removes weekends from the calculation and outputs a `report.csv` file summarizing hours in each queue.

--- a/readme.md
+++ b/readme.md
@@ -82,10 +82,18 @@ Open an issue or contact Valis.
 
 Lead Time Report
 ----------------
-The `lead_time_report.py` script generates a CSV report showing how long jobs spend in each workstation queue. The input CSV must contain the columns `job_number`, `step`, `time_in`, and `time_out` where the timestamps are in `YYYY-MM-DD HH:MM:SS` format. Usage:
+The `lead_time_report.py` script generates a CSV report showing how long jobs spend in each workstation queue using a CSV export. The CSV must contain the columns `job_number`, `step`, `time_in`, and `time_out` where the timestamps are in `YYYY-MM-DD HH:MM:SS` format. Usage:
 
 ```bash
 python lead_time_report.py data.csv --start 2024-01-01 --end 2024-01-31 --output report.csv
 ```
 
 The script removes weekends from the calculation and outputs a `report.csv` file summarizing hours in each queue.
+
+You can also parse a saved `manage.html` file with `manage_html_report.py`:
+
+```bash
+python manage_html_report.py manage.html --output report.csv
+```
+
+This reads the workstation timestamps from the HTML table and produces the same style report.

--- a/test_lead_time_report.py
+++ b/test_lead_time_report.py
@@ -1,0 +1,33 @@
+import unittest
+from datetime import datetime
+from lead_time_report import compute_lead_times, business_hours_delta
+
+class LeadTimeTests(unittest.TestCase):
+    def test_business_hours_skip_weekend(self):
+        start = datetime(2024, 1, 5, 16, 0)  # Friday 4pm
+        end = datetime(2024, 1, 8, 10, 0)    # Monday 10am
+        delta = business_hours_delta(start, end)
+        self.assertEqual(delta.total_seconds() / 3600, 18)  # 18 hours (weekend excluded)
+
+    def test_compute_lead_times(self):
+        rows = [
+            {
+                "job_number": "1001",
+                "step": "print",
+                "time_in": datetime(2024, 1, 2, 8, 0),
+                "time_out": datetime(2024, 1, 2, 12, 0),
+            },
+            {
+                "job_number": "1001",
+                "step": "laminate",
+                "time_in": datetime(2024, 1, 3, 8, 0),
+                "time_out": datetime(2024, 1, 3, 10, 0),
+            },
+        ]
+        res = compute_lead_times(rows)
+        self.assertEqual(len(res["1001"]), 2)
+        self.assertAlmostEqual(res["1001"][0]["hours"], 4)
+        self.assertAlmostEqual(res["1001"][1]["hours"], 2)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_manage_html_report.py
+++ b/test_manage_html_report.py
@@ -1,0 +1,49 @@
+import unittest
+import tempfile
+import os
+from datetime import datetime
+from manage_html_report import parse_manage_html, compute_lead_times
+
+SAMPLE_HTML = '''
+<tbody id="table">
+<tr data-id="1">
+<td class="move"><p>YBS 1001</p></td>
+<td></td>
+<td></td>
+<td>
+<ul class="workplaces">
+<li><p><span class="circle green-step">0</span>Print Files YBS</p><p class="np">07/22/25 10:00</p></li>
+<li><p><span class="circle green-step">0</span>Indigo</p><p class="np">07/23/25 15:00</p></li>
+<li class="active_ws"><p><span class="circle"></span>Laminate</p><p class="np">&nbsp;</p></li>
+</ul>
+</td>
+</tr>
+</tbody>
+'''
+
+class ManageHTMLTests(unittest.TestCase):
+    def test_parse_manage_html(self):
+        with tempfile.NamedTemporaryFile('w+', delete=False, suffix='.html') as tmp:
+            tmp.write(SAMPLE_HTML)
+            tmp_path = tmp.name
+        jobs = parse_manage_html(tmp_path)
+        self.assertIn('1001', jobs)
+        steps = jobs['1001']
+        self.assertEqual(len(steps), 3)
+        self.assertEqual(steps[0][0], 'Print Files YBS')
+        self.assertIsInstance(steps[0][1], datetime)
+        self.assertIsNone(steps[2][1])
+        os.remove(tmp_path)
+
+    def test_compute_lead_times(self):
+        with tempfile.NamedTemporaryFile('w+', delete=False, suffix='.html') as tmp:
+            tmp.write(SAMPLE_HTML)
+            tmp_path = tmp.name
+        jobs = parse_manage_html(tmp_path)
+        results = compute_lead_times(jobs)
+        hours = results['1001'][0]['hours']
+        self.assertAlmostEqual(hours, 29.0)
+        os.remove(tmp_path)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `lead_time_report.py` for computing job queue times from a CSV
- document new script usage in README
- include unit tests for lead time calculations

## Testing
- `python3 test_lead_time_report.py`

------
https://chatgpt.com/codex/tasks/task_e_688ace73e438832db2b12d1934f21f75