### PR TITLE
Add date range filtering to manage_html_report

### DIFF
--- a/manage_html_report.py
+++ b/manage_html_report.py
@@ -1,17 +1,24 @@
+import argparse
 import csv
 import re
-from datetime import datetime, timedelta
 from collections import defaultdict
+from datetime import datetime, timedelta
+
 from bs4 import BeautifulSoup
-import argparse
 
 HTML_DATE_FORMAT = "%m/%d/%y %H:%M"
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Generate lead time report from manage.html")
+    parser = argparse.ArgumentParser(
+        description="Generate lead time report from manage.html"
+    )
     parser.add_argument("html_file", help="Path to manage.html")
-    parser.add_argument("--output", default="lead_time_report.csv", help="Output CSV path")
+    parser.add_argument(
+        "--output", default="lead_time_report.csv", help="Output CSV path"
+    )
+    parser.add_argument("--start", help="Start date (YYYY-MM-DD)")
+    parser.add_argument("--end", help="End date (YYYY-MM-DD)")
     return parser.parse_args()
 
 
@@ -19,7 +26,9 @@ def business_hours_delta(start, end):
     total = timedelta(0)
     current = start
     while current < end:
-        next_day = (current + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+        next_day = (current + timedelta(days=1)).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
         working_end = min(next_day, end)
         if current.weekday() < 5:
             total += working_end - current
@@ -60,24 +69,34 @@ def parse_manage_html(path):
     return jobs
 
 
-def compute_lead_times(jobs):
-    """Return hours spent in each workstation including timestamps."""
+def compute_lead_times(jobs, start_date=None, end_date=None):
+    """Return hours spent in each workstation including timestamps.
+
+    Only include steps where the start timestamp is on or after ``start_date``
+    and the end timestamp is on or before ``end_date``.
+    """
+
     results = defaultdict(list)
     for job, steps in jobs.items():
         for i in range(len(steps) - 1):
             name, start = steps[i]
             next_name, end = steps[i + 1]
-            if start and end:
-                delta = business_hours_delta(start, end)
-                hours = delta.total_seconds() / 3600.0
-                results[job].append(
-                    {
-                        "step": next_name,
-                        "hours": hours,
-                        "start": start,
-                        "end": end,
-                    }
-                )
+            if not start or not end:
+                continue
+            if start_date and start < start_date:
+                continue
+            if end_date and end > end_date:
+                continue
+            delta = business_hours_delta(start, end)
+            hours = delta.total_seconds() / 3600.0
+            results[job].append(
+                {
+                    "step": next_name,
+                    "hours": hours,
+                    "start": start,
+                    "end": end,
+                }
+            )
     return results
 
 
@@ -103,7 +122,9 @@ def write_report(results, path):
 def main():
     args = parse_args()
     jobs = parse_manage_html(args.html_file)
-    results = compute_lead_times(jobs)
+    start = datetime.strptime(args.start, "%Y-%m-%d") if args.start else None
+    end = datetime.strptime(args.end, "%Y-%m-%d") if args.end else None
+    results = compute_lead_times(jobs, start, end)
     write_report(results, args.output)
     print(f"Report written to {args.output}")
 

--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,8 @@ The script removes weekends from the calculation and outputs a `report.csv` file
 You can also parse a saved `manage.html` file with `manage_html_report.py`:
 
 ```bash
-python manage_html_report.py manage.html --output report.csv
+python manage_html_report.py manage.html --output report.csv \
+    --start 2024-01-01 --end 2024-01-31
 ```
 
 This reads the workstation timestamps from the HTML table and produces the same style report.

--- a/test_manage_html_report.py
+++ b/test_manage_html_report.py
@@ -1,10 +1,11 @@
-import unittest
-import tempfile
 import os
+import tempfile
+import unittest
 from datetime import datetime
-from manage_html_report import parse_manage_html, compute_lead_times
 
-SAMPLE_HTML = '''
+from manage_html_report import compute_lead_times, parse_manage_html
+
+SAMPLE_HTML = """
 <tbody id="table">
 <tr data-id="1">
 <td class="move"><p>YBS 1001</p></td>
@@ -19,33 +20,45 @@ SAMPLE_HTML = '''
 </td>
 </tr>
 </tbody>
-'''
+"""
+
 
 class ManageHTMLTests(unittest.TestCase):
     def test_parse_manage_html(self):
-        with tempfile.NamedTemporaryFile('w+', delete=False, suffix='.html') as tmp:
+        with tempfile.NamedTemporaryFile("w+", delete=False, suffix=".html") as tmp:
             tmp.write(SAMPLE_HTML)
             tmp_path = tmp.name
         jobs = parse_manage_html(tmp_path)
-        self.assertIn('1001', jobs)
-        steps = jobs['1001']
+        self.assertIn("1001", jobs)
+        steps = jobs["1001"]
         self.assertEqual(len(steps), 3)
-        self.assertEqual(steps[0][0], 'Print Files YBS')
+        self.assertEqual(steps[0][0], "Print Files YBS")
         self.assertIsInstance(steps[0][1], datetime)
         self.assertIsNone(steps[2][1])
         os.remove(tmp_path)
 
     def test_compute_lead_times(self):
-        with tempfile.NamedTemporaryFile('w+', delete=False, suffix='.html') as tmp:
+        with tempfile.NamedTemporaryFile("w+", delete=False, suffix=".html") as tmp:
             tmp.write(SAMPLE_HTML)
             tmp_path = tmp.name
         jobs = parse_manage_html(tmp_path)
         results = compute_lead_times(jobs)
-        entry = results['1001'][0]
-        self.assertAlmostEqual(entry['hours'], 29.0)
-        self.assertIsInstance(entry['start'], datetime)
-        self.assertIsInstance(entry['end'], datetime)
+        entry = results["1001"][0]
+        self.assertAlmostEqual(entry["hours"], 29.0)
+        self.assertIsInstance(entry["start"], datetime)
+        self.assertIsInstance(entry["end"], datetime)
         os.remove(tmp_path)
 
-if __name__ == '__main__':
+    def test_compute_lead_times_date_range(self):
+        with tempfile.NamedTemporaryFile("w+", delete=False, suffix=".html") as tmp:
+            tmp.write(SAMPLE_HTML)
+            tmp_path = tmp.name
+        jobs = parse_manage_html(tmp_path)
+        start = datetime(2025, 7, 23)
+        results = compute_lead_times(jobs, start_date=start)
+        self.assertEqual(len(results["1001"]), 0)
+        os.remove(tmp_path)
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- allow specifying `--start` and `--end` when running `manage_html_report.py`
- filter steps by the provided date range when computing lead times
- document the new feature in `readme.md`
- test date range filtering in `test_manage_html_report.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae7ae8184832db917266861b0fb22