### PR TITLE
Handle request timeouts

### DIFF
--- a/YBS_CONTROL.py
+++ b/YBS_CONTROL.py
@@ -161,7 +161,11 @@ class OrderScraperApp:
             'action': 'signin',
         }
         login_url = self.login_url_var.get() or LOGIN_URL
-        resp = self.session.post(login_url, data=data)
+        try:
+            resp = self.session.post(login_url, data=data, timeout=10)
+        except requests.RequestException as e:
+            messagebox.showerror("Login", f"Login request failed: {e}")
+            return
         orders_page = os.path.basename(self.orders_url_var.get() or ORDERS_URL).lower()
         if "logout" in resp.text.lower() or orders_page in resp.text.lower():
             self.logged_in = True
@@ -180,7 +184,11 @@ class OrderScraperApp:
             messagebox.showerror("Error", "Not logged in!")
             return
         orders_url = self.orders_url_var.get() or ORDERS_URL
-        resp = self.session.get(orders_url)
+        try:
+            resp = self.session.get(orders_url, timeout=10)
+        except requests.RequestException as e:
+            messagebox.showerror("Error", f"Failed to fetch orders: {e}")
+            return
         soup = BeautifulSoup(resp.text, 'html.parser')
         tbody = soup.find('tbody', id='table')
         self.orders_tree.delete(*self.orders_tree.get_children())

--- a/test_YBS_CONTROL.py
+++ b/test_YBS_CONTROL.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import requests
+
+from YBS_CONTROL import OrderScraperApp
+
+
+class SimpleVar:
+    def __init__(self, value=""):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+    def set(self, value):
+        self.value = value
+
+
+class YBSControlTests(unittest.TestCase):
+    def setUp(self):
+        self.app = OrderScraperApp.__new__(OrderScraperApp)
+        self.app.session = MagicMock()
+        self.app.username_var = SimpleVar("user")
+        self.app.password_var = SimpleVar("pass")
+        self.app.login_url_var = SimpleVar("http://example.com/login")
+        self.app.orders_url_var = SimpleVar("http://example.com/orders")
+        self.app.tab_control = MagicMock()
+        self.app.logged_in = True
+        self.app.orders_tree = MagicMock()
+        self.app.order_rows = []
+
+    @patch("YBS_CONTROL.messagebox")
+    def test_login_request_exception(self, mock_messagebox):
+        self.app.get_orders = MagicMock()
+        self.app.session.post.side_effect = requests.Timeout("boom")
+        self.app.login()
+        self.app.session.post.assert_called_with(
+            "http://example.com/login",
+            data={"email": "user", "password": "pass", "action": "signin"},
+            timeout=10,
+        )
+        mock_messagebox.showerror.assert_called_once()
+        self.app.get_orders.assert_not_called()
+
+    @patch("YBS_CONTROL.messagebox")
+    def test_get_orders_request_exception(self, mock_messagebox):
+        self.app.session.get.side_effect = requests.RequestException("fail")
+        self.app.get_orders()
+        self.app.session.get.assert_called_with("http://example.com/orders", timeout=10)
+        mock_messagebox.showerror.assert_called_once()
+        self.app.orders_tree.delete.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- handle request timeouts when logging in and fetching orders
- add regression tests for login and order retrieval failures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c39843c78832da9b32977228997c6