### PR TITLE
Use regex for job ID parsing and add tests

### DIFF
--- a/manage_html_report.py
+++ b/manage_html_report.py
@@ -1,6 +1,7 @@
 import argparse
 import csv
 import re
+import logging
 from collections import defaultdict
 from datetime import datetime
 
@@ -33,10 +34,11 @@ def parse_manage_html(path):
         if not move_td:
             continue
         job_text = move_td.get_text(strip=True)
-        parts = job_text.split()
-        job_number = parts[-1] if parts else None
-        if not job_number:
+        match = re.search(r"\b(\d+)\b", job_text)
+        if not match:
+            logging.warning("Could not find job ID in row: %s", job_text)
             continue
+        job_number = match.group(1)
         steps = []
         for li in tr.select("ul.workplaces li"):
             step_p = li.find("p")

--- a/test_manage_html_report.py
+++ b/test_manage_html_report.py
@@ -22,6 +22,22 @@ SAMPLE_HTML = """
 </tbody>
 """
 
+SAMPLE_HTML_TEMPLATE = """
+<tbody id="table">
+<tr data-id="1">
+<td class="move"><p>{job_text}</p></td>
+<td></td>
+<td></td>
+<td>
+<ul class="workplaces">
+<li><p><span class="circle"></span>Step1</p><p class="np">07/22/25 10:00</p></li>
+<li class="active_ws"><p><span class="circle"></span>Step2</p><p class="np">&nbsp;</p></li>
+</ul>
+</td>
+</tr>
+</tbody>
+"""
+
 
 class ManageHTMLTests(unittest.TestCase):
     def test_parse_manage_html(self):
@@ -35,6 +51,33 @@ class ManageHTMLTests(unittest.TestCase):
         self.assertEqual(steps[0][0], "Print Files YBS")
         self.assertIsInstance(steps[0][1], datetime)
         self.assertIsNone(steps[2][1])
+        os.remove(tmp_path)
+
+    def test_parse_manage_html_trailing_punctuation(self):
+        html = SAMPLE_HTML_TEMPLATE.format(job_text="YBS 1002.")
+        with tempfile.NamedTemporaryFile("w+", delete=False, suffix=".html") as tmp:
+            tmp.write(html)
+            tmp_path = tmp.name
+        jobs = parse_manage_html(tmp_path)
+        self.assertIn("1002", jobs)
+        os.remove(tmp_path)
+
+    def test_parse_manage_html_additional_text(self):
+        html = SAMPLE_HTML_TEMPLATE.format(job_text="Order 1003 extra")
+        with tempfile.NamedTemporaryFile("w+", delete=False, suffix=".html") as tmp:
+            tmp.write(html)
+            tmp_path = tmp.name
+        jobs = parse_manage_html(tmp_path)
+        self.assertIn("1003", jobs)
+        os.remove(tmp_path)
+
+    def test_parse_manage_html_skips_non_numeric(self):
+        html = SAMPLE_HTML_TEMPLATE.format(job_text="No digits here")
+        with tempfile.NamedTemporaryFile("w+", delete=False, suffix=".html") as tmp:
+            tmp.write(html)
+            tmp_path = tmp.name
+        jobs = parse_manage_html(tmp_path)
+        self.assertEqual(jobs, {})
         os.remove(tmp_path)
 
     def test_compute_lead_times(self):


### PR DESCRIPTION
## Summary
- Extract job IDs from job text using a regex and log warnings when missing
- Add regression tests for job numbers with extra punctuation or words

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c45623af8832dafcf9a7328563210