### PR TITLE
Restrict lead time calculation to business hours

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,11 @@ The `lead_time_report.py` script generates a CSV report showing how long jobs sp
 python lead_time_report.py data.csv --start 2024-01-01 --end 2024-01-31 --output report.csv
 ```
 
-The script removes weekends from the calculation and outputs a `report.csv` file summarizing hours in each queue.
+The script calculates time spent in each queue using business hours
+(8:00–16:30, Monday–Friday) and excludes weekends from the
+calculation. A helper `business_hours_breakdown()` function in
+`time_utils.py` can be used to inspect the exact segments counted if you
+need to verify how business hours were applied.
 
 Date range filtering is available directly in the GUI. Enter a start and/or end
 date on the Orders tab (in `YYYY-MM-DD` format) and use **Export Date Range** to

--- a/test_manage_html_report.py
+++ b/test_manage_html_report.py
@@ -90,7 +90,7 @@ class ManageHTMLTests(unittest.TestCase):
         jobs = parse_manage_html(self.tmp_path)
         results = compute_lead_times(jobs)
         entry = results["1001"][0]
-        self.assertAlmostEqual(entry["hours"], 29.0)
+        self.assertAlmostEqual(entry["hours"], 13.5)
         self.assertIsInstance(entry["start"], datetime)
         self.assertIsInstance(entry["end"], datetime)
 

--- a/test_time_utils.py
+++ b/test_time_utils.py
@@ -1,7 +1,7 @@
 import unittest
 from datetime import datetime
 
-from time_utils import business_hours_delta
+from time_utils import business_hours_delta, business_hours_breakdown
 
 
 class TimeUtilsTests(unittest.TestCase):
@@ -9,7 +9,14 @@ class TimeUtilsTests(unittest.TestCase):
         start = datetime(2024, 1, 5, 16, 0)  # Friday 4pm
         end = datetime(2024, 1, 8, 10, 0)  # Monday 10am
         delta = business_hours_delta(start, end)
-        self.assertEqual(delta.total_seconds() / 3600, 18)  # 18 hours (weekend excluded)
+        self.assertEqual(delta.total_seconds() / 3600, 2.5)  # 2.5 hours within business hours
+
+        segments = business_hours_breakdown(start, end)
+        expected = [
+            (datetime(2024, 1, 5, 16, 0), datetime(2024, 1, 5, 16, 30)),
+            (datetime(2024, 1, 8, 8, 0), datetime(2024, 1, 8, 10, 0)),
+        ]
+        self.assertEqual(segments, expected)
 
 
 if __name__ == "__main__":

--- a/time_utils.py
+++ b/time_utils.py
@@ -1,16 +1,63 @@
-from datetime import datetime, timedelta
+"""Utilities for working with business hours."""
+
+from datetime import datetime, timedelta, time
+
+
+BUSINESS_START = time(8, 0)
+BUSINESS_END = time(16, 30)
+
+
+def _next_business_start(dt: datetime) -> datetime:
+    """Return the next datetime at the start of business hours."""
+    next_day = dt + timedelta(days=1)
+    return next_day.replace(
+        hour=BUSINESS_START.hour, minute=BUSINESS_START.minute, second=0, microsecond=0
+    )
+
+
+def business_hours_breakdown(start: datetime, end: datetime):
+    """Return a list of (segment_start, segment_end) within business hours.
+
+    Business hours are 8:00–16:30 Monday–Friday. Weekends are excluded.
+    """
+
+    segments = []
+    current = start
+    while current < end:
+        # Skip weekends entirely
+        if current.weekday() >= 5:
+            current = _next_business_start(current)
+            continue
+
+        day_start = current.replace(
+            hour=BUSINESS_START.hour, minute=BUSINESS_START.minute, second=0, microsecond=0
+        )
+        day_end = current.replace(
+            hour=BUSINESS_END.hour, minute=BUSINESS_END.minute, second=0, microsecond=0
+        )
+
+        if current < day_start:
+            current = day_start
+        if current >= day_end:
+            current = _next_business_start(current)
+            continue
+
+        segment_end = min(day_end, end)
+        segments.append((current, segment_end))
+        current = _next_business_start(current)
+
+    return segments
 
 
 def business_hours_delta(start: datetime, end: datetime) -> timedelta:
-    total = timedelta(0)
-    current = start
-    while current < end:
-        next_day = (current + timedelta(days=1)).replace(
-            hour=0, minute=0, second=0, microsecond=0
-        )
-        working_end = min(next_day, end)
-        # skip weekends
-        if current.weekday() < 5:
-            total += working_end - current
-        current = next_day
+    """Return the business time between ``start`` and ``end``.
+
+    Only hours between 08:00 and 16:30 on weekdays are counted.
+    """
+
+    if start >= end:
+        return timedelta(0)
+    total = timedelta()
+    for seg_start, seg_end in business_hours_breakdown(start, end):
+        total += seg_end - seg_start
     return total


### PR DESCRIPTION
## Summary
- compute time deltas using 8:00–16:30 weekday business hours
- expose `business_hours_breakdown` to inspect per-day segments
- document business hour handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c4fdde514832d8e2834205c4585fc