### PR TITLE
Show all workstations in realtime report

### DIFF
--- a/test_YBS_CONTROL.py
+++ b/test_YBS_CONTROL.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import requests
 
 from YBS_CONTROL import OrderScraperApp
+from datetime import datetime
 
 
 class SimpleVar:
@@ -73,6 +74,30 @@ class YBSControlTests(unittest.TestCase):
         self.app.orders_tree.insert.assert_called_once()
         args, kwargs = self.app.orders_tree.insert.call_args
         self.assertEqual(kwargs["values"], ("12345", "ACME Corp", "Running", "High"))
+
+    def test_show_report_displays_all_workstations(self):
+        self.app.start_date_var = SimpleVar("")
+        self.app.end_date_var = SimpleVar("")
+        # simulate order selection
+        self.app.orders_tree.focus.return_value = "item1"
+        self.app.orders_tree.item.return_value = ("123",)
+        # steps contain a workstation without a timestamp
+        t1 = datetime(2024, 1, 1, 8, 0)
+        self.app.load_steps = MagicMock(return_value=[("Cutting", t1), ("Welding", None)])
+        self.app.load_lead_times = MagicMock(return_value=[])
+        self.app.report_tree = MagicMock()
+        db_cursor = MagicMock()
+        db_cursor.fetchall.return_value = []
+        self.app.db = MagicMock()
+        self.app.db.cursor.return_value = db_cursor
+
+        self.app.show_report()
+
+        insert_calls = self.app.report_tree.insert.call_args_list
+        # Cutting, Welding, TOTAL
+        self.assertEqual(len(insert_calls), 3)
+        self.assertEqual(insert_calls[0].kwargs["values"][0], "Cutting")
+        self.assertEqual(insert_calls[1].kwargs["values"][0], "Welding")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Ensure realtime reporting lists every workstation and computes hours when possible
- Add regression test for showing workstations lacking timestamps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68993c077778832d9237b02e02a496c2