### PR TITLE
Add configurable database path

### DIFF
--- a/test_YBS_CONTROL.py
+++ b/test_YBS_CONTROL.py
@@ -99,6 +99,17 @@ class YBSControlTests(unittest.TestCase):
         self.assertEqual(insert_calls[0].kwargs["values"][0], "Cutting")
         self.assertEqual(insert_calls[1].kwargs["values"][0], "Welding")
 
+    @patch("YBS_CONTROL.sqlite3.connect")
+    def test_connect_db_allows_network_path(self, mock_connect):
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_connect.return_value = mock_conn
+        self.app.db_path_var = SimpleVar("orders.db")
+        self.app.db = MagicMock()
+        OrderScraperApp.connect_db(self.app, r"\\server\share\orders.db")
+        mock_connect.assert_called_with(r"\\server\share\orders.db")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- allow users to configure the SQLite database location and browse to paths, including network drives
- test database connection to custom network path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899401b0ca8832d9881fb75a28d606a