### PR TITLE
Clarify business hours docstrings

### DIFF
--- a/time_utils.py
+++ b/time_utils.py
@@ -8,7 +8,16 @@ BUSINESS_END = time(16, 30)
 
 
 def _next_business_start(dt: datetime) -> datetime:
-    """Return the next datetime at the start of business hours."""
+    """Return the next datetime aligned with the start of business hours.
+
+    Steps:
+    1. Add one calendar day to ``dt``.
+    2. Replace the time portion with ``BUSINESS_START`` (08:00).
+    3. Return the normalized datetime.
+
+    The helper itself does not skip weekends; callers should continue
+    invoking it until a weekday is reached.
+    """
     next_day = dt + timedelta(days=1)
     return next_day.replace(
         hour=BUSINESS_START.hour, minute=BUSINESS_START.minute, second=0, microsecond=0
@@ -16,9 +25,28 @@ def _next_business_start(dt: datetime) -> datetime:
 
 
 def business_hours_breakdown(start: datetime, end: datetime):
-    """Return a list of (segment_start, segment_end) within business hours.
+    """Return a list of business-hour segments between ``start`` and ``end``.
 
-    Business hours are 8:00–16:30 Monday–Friday. Weekends are excluded.
+    Steps:
+    1. Iterate from ``start`` until ``end``.
+    2. Skip Saturdays and Sundays by jumping to the next business start.
+    3. For each weekday, compute the 08:00 ``day_start`` and 16:30 ``day_end``.
+    4. Snap the current time to ``day_start`` if it falls earlier.
+    5. If the current time is past ``day_end``, move to the next day.
+    6. Record a segment from the current time to the earlier of ``day_end`` or ``end``.
+    7. Advance to the next day's start and repeat.
+
+    Example:
+        >>> from datetime import datetime
+        >>> business_hours_breakdown(
+        ...     datetime(2024, 1, 5, 16, 0), datetime(2024, 1, 8, 10, 0)
+        ... )
+        [(datetime(2024, 1, 5, 16, 0), datetime(2024, 1, 5, 16, 30)),
+         (datetime(2024, 1, 8, 8, 0), datetime(2024, 1, 8, 10, 0))]
+
+    Weekends are skipped entirely, days are segmented by business start and
+    end, and the return value lists each contiguous span that contributes
+    to business time.
     """
 
     segments = []
@@ -50,9 +78,15 @@ def business_hours_breakdown(start: datetime, end: datetime):
 
 
 def business_hours_delta(start: datetime, end: datetime) -> timedelta:
-    """Return the business time between ``start`` and ``end``.
+    """Return the total business time between ``start`` and ``end``.
 
-    Only hours between 08:00 and 16:30 on weekdays are counted.
+    Steps:
+    1. If ``start`` is not before ``end``, return ``timedelta(0)``.
+    2. Use :func:`business_hours_breakdown` to obtain all weekday segments.
+    3. Sum the duration of each segment to compute the total.
+
+    Only hours between 08:00 and 16:30 on weekdays contribute to the
+    total because weekend periods are skipped by the breakdown.
     """
 
     if start >= end:


### PR DESCRIPTION
## Summary
- expand `_next_business_start` docstring with algorithm and weekend note
- detail `business_hours_breakdown` steps, add usage example, explain weekend skipping and segmentation
- explain `business_hours_delta` computation using breakdown segments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68994f8628c4832dafd16a4b1e38cb44