### PR TITLE
Use open dialog for existing database selection

### DIFF
--- a/YBS_CONTROL.py
+++ b/YBS_CONTROL.py
@@ -546,8 +546,7 @@ class OrderScraperApp:
         messagebox.showinfo("Breakdown", "\n".join(lines) if lines else "No breakdown data")
 
     def browse_db(self):
-        path = filedialog.asksaveasfilename(
-            defaultextension=".db",
+        path = filedialog.askopenfilename(
             filetypes=[("SQLite DB", "*.db"), ("All Files", "*")],
             initialdir=self.last_db_dir,
         )

--- a/test_YBS_CONTROL.py
+++ b/test_YBS_CONTROL.py
@@ -131,7 +131,7 @@ class YBSControlTests(unittest.TestCase):
         time_utils.BUSINESS_START = time(8, 0)
         time_utils.BUSINESS_END = time(16, 30)
 
-    @patch("YBS_CONTROL.filedialog.asksaveasfilename", return_value="/tmp/orders.db")
+    @patch("YBS_CONTROL.filedialog.askopenfilename", return_value="/tmp/orders.db")
     def test_browse_db_uses_last_directory(self, mock_dialog):
         self.app.last_db_dir = "/tmp"
         self.app.connect_db = MagicMock()


### PR DESCRIPTION
## Summary
- Swap database browse dialog to use `askopenfilename` so selecting an existing DB doesn't prompt to overwrite
- Update tests to patch new dialog function and verify last directory is used

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6899590dbfe0832d8a55d5dd3848f913