### PR TITLE
Fetch orders only on successful login

### DIFF
--- a/YBS_CONTROL.py
+++ b/YBS_CONTROL.py
@@ -224,7 +224,8 @@ class OrderScraperApp:
         else:
             self.logged_in = False
             messagebox.showerror("Login", "Login failed.")
-        self.get_orders()
+        if self.logged_in:
+            self.get_orders()
 
     def get_orders(self):
         if not self.logged_in:

--- a/test_YBS_CONTROL.py
+++ b/test_YBS_CONTROL.py
@@ -141,6 +141,24 @@ class YBSControlTests(unittest.TestCase):
         self.assertEqual(kwargs.get("initialdir"), "/tmp")
         self.app.connect_db.assert_called_with("/tmp/orders.db")
 
+    @patch("YBS_CONTROL.messagebox")
+    def test_handle_login_response_triggers_get_orders_only_on_success(self, mock_messagebox):
+        self.app.get_orders = MagicMock()
+        self.app.refresh_entry = MagicMock()
+        self.app.refresh_button = MagicMock()
+        self.app.schedule_auto_refresh = MagicMock()
+        mock_resp = MagicMock()
+
+        # simulate login failure
+        mock_resp.text = "login failed"
+        self.app._handle_login_response(mock_resp)
+        self.app.get_orders.assert_not_called()
+
+        # simulate login success
+        mock_resp.text = "logout"
+        self.app._handle_login_response(mock_resp)
+        self.app.get_orders.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Only call `get_orders` after a successful login
- Add regression test for login response handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68996376ebc4832d8a43556b1c40b437