### PR TITLE
Move analytics chart to pop-out window with vertical labels

### DIFF
--- a/test_YBS_CONTROL.py
+++ b/test_YBS_CONTROL.py
@@ -202,7 +202,7 @@ class YBSControlTests(unittest.TestCase):
         self.assertEqual(time_utils.BUSINESS_START, time(9, 0))
         self.assertEqual(time_utils.BUSINESS_END, time(17, 0))
         tabs_added = [call.args[0] for call in mock_tabview.return_value.add.call_args_list]
-        self.assertIn("Analytics", tabs_added)
+        self.assertNotIn("Analytics", tabs_added)
         # reset defaults
         time_utils.BUSINESS_START = time(8, 0)
         time_utils.BUSINESS_END = time(16, 30)


### PR DESCRIPTION
## Summary
- Replace analytics tab with a pop-out analytics window and button to launch it
- Rotate x-axis labels in analytics bar chart to avoid overlap
- Adjust tests for new analytics window behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689970e975c4832d8f7be520405ced93