### PR TITLE
Add production report export utilities and CLI

### DIFF
--- a/production_report.py
+++ b/production_report.py
@@ -12,6 +12,11 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 from typing import Dict, Iterable, List
+import csv
+import json
+import os
+import sys
+import argparse
 
 
 def _parse_datetime(value):
@@ -138,4 +143,196 @@ def generate_production_report(
     totals["grand_total"] = round(sum(totals_by_ws.values()), 2)
 
     return {"summary": summary, "totals": totals, "details": details}
+
+
+def _build_summary_table(report: Dict[str, object]):
+    """Return headers and rows for the summary portion of ``report``.
+
+    The function returns a tuple ``(headers, rows)`` where ``headers`` is a
+    list of column names and ``rows`` a list of row data ready for export.
+    ``report`` is expected to be the structure produced by
+    :func:`generate_production_report`.
+    """
+
+    summary = report.get("summary", [])
+    totals = report.get("totals", {})
+    # Discover all workstations used in the report
+    workstations = sorted({ws for s in summary for ws in s["workstations"]})
+
+    headers = ["Order ID", *workstations, "Order Total"]
+    rows: List[List[str]] = []
+    for s in summary:
+        row = [s["orderId"]]
+        for ws in workstations:
+            row.append(f"{s['workstations'].get(ws, 0):.2f}")
+        row.append(f"{s['order_total']:.2f}")
+        rows.append(row)
+
+    total_row = ["Totals"]
+    for ws in workstations:
+        total_row.append(f"{totals.get(ws, 0):.2f}")
+    total_row.append(f"{totals.get('grand_total', 0):.2f}")
+    rows.append(total_row)
+    return headers, rows
+
+
+def _build_detail_table(report: Dict[str, object]):
+    """Return headers and rows for the detail portion of ``report``."""
+
+    headers = ["Order ID", "Workstation", "Start", "End", "Hours"]
+    rows = []
+    for d in report.get("details", []):
+        rows.append(
+            [
+                d.get("orderId"),
+                d.get("workstation"),
+                str(d.get("start")),
+                str(d.get("end")),
+                f"{d.get('hours', 0):.2f}",
+            ]
+        )
+    return headers, rows
+
+
+def export_to_csv(report: Dict[str, object], out_dir: str) -> None:
+    """Write ``report`` to ``out_dir`` as ``Summary.csv`` and ``Details.csv``."""
+
+    os.makedirs(out_dir, exist_ok=True)
+
+    summary_headers, summary_rows = _build_summary_table(report)
+    with open(os.path.join(out_dir, "Summary.csv"), "w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(summary_headers)
+        writer.writerows(summary_rows)
+
+    detail_headers, detail_rows = _build_detail_table(report)
+    with open(os.path.join(out_dir, "Details.csv"), "w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(detail_headers)
+        writer.writerows(detail_rows)
+
+
+def export_to_sheets(report: Dict[str, object], sheet_id: str) -> None:
+    """Export ``report`` to a Google Sheets spreadsheet ``sheet_id``.
+
+    The function creates/clears ``Summary`` and ``Details`` worksheets and
+    populates them with the report data.  Basic formatting such as freezing
+    the top five rows and first column, auto-sizing columns, two decimal number
+    formatting and borders are applied.
+    """
+
+    import gspread  # Imported lazily as this is an optional dependency
+
+    client = gspread.service_account()
+    spreadsheet = client.open_by_key(sheet_id)
+
+    def _upsert_ws(title, headers, rows):
+        cols = len(headers)
+        rows_len = len(rows) + 1
+        try:
+            ws = spreadsheet.worksheet(title)
+            ws.clear()
+        except gspread.WorksheetNotFound:
+            ws = spreadsheet.add_worksheet(title=title, rows=rows_len, cols=cols)
+        ws.update("A5", [headers] + rows)
+
+        spreadsheet.batch_update(
+            {
+                "requests": [
+                    {
+                        "updateSheetProperties": {
+                            "properties": {
+                                "sheetId": ws.id,
+                                "gridProperties": {
+                                    "frozenRowCount": 5,
+                                    "frozenColumnCount": 1,
+                                },
+                            },
+                            "fields": "gridProperties(frozenRowCount,frozenColumnCount)",
+                        }
+                    },
+                    {
+                        "autoResizeDimensions": {
+                            "dimensions": {
+                                "sheetId": ws.id,
+                                "dimension": "COLUMNS",
+                                "startIndex": 0,
+                                "endIndex": cols,
+                            }
+                        }
+                    },
+                    {
+                        "repeatCell": {
+                            "range": {
+                                "sheetId": ws.id,
+                                "startRowIndex": 5,
+                                "startColumnIndex": 1,
+                                "endRowIndex": rows_len + 5,
+                                "endColumnIndex": cols,
+                            },
+                            "cell": {
+                                "userEnteredFormat": {
+                                    "numberFormat": {
+                                        "type": "NUMBER",
+                                        "pattern": "0.00",
+                                    }
+                                }
+                            },
+                            "fields": "userEnteredFormat.numberFormat",
+                        }
+                    },
+                    {
+                        "updateBorders": {
+                            "range": {
+                                "sheetId": ws.id,
+                                "startRowIndex": 4,
+                                "startColumnIndex": 0,
+                                "endRowIndex": rows_len + 5,
+                                "endColumnIndex": cols,
+                            },
+                            "top": {"style": "SOLID", "width": 1},
+                            "bottom": {"style": "SOLID", "width": 1},
+                            "left": {"style": "SOLID", "width": 1},
+                            "right": {"style": "SOLID", "width": 1},
+                            "innerHorizontal": {"style": "SOLID", "width": 1},
+                            "innerVertical": {"style": "SOLID", "width": 1},
+                        }
+                    },
+                ]
+            }
+        )
+
+    summary_headers, summary_rows = _build_summary_table(report)
+    detail_headers, detail_rows = _build_detail_table(report)
+    _upsert_ws("Summary", summary_headers, summary_rows)
+    _upsert_ws("Details", detail_headers, detail_rows)
+
+
+def main(argv: List[str] | None = None) -> None:
+    """Entry point for command line usage.
+
+    Events are expected as JSON on ``stdin``.  The output destination must be
+    specified using ``--sheet-id`` or ``--csv-dir``.
+    """
+
+    parser = argparse.ArgumentParser(description="Generate production report")
+    parser.add_argument("--start", required=True, help="Start time (ISO format)")
+    parser.add_argument("--end", required=True, help="End time (ISO format)")
+    parser.add_argument("--timezone", default="UTC", help="IANA timezone")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--sheet-id", help="Destination Google Sheet ID")
+    group.add_argument("--csv-dir", help="Directory to write CSV files")
+    args = parser.parse_args(argv)
+
+    events = json.load(sys.stdin)
+    report = generate_production_report(events, args.start, args.end, args.timezone)
+
+    if args.sheet_id:
+        export_to_sheets(report, args.sheet_id)
+    else:
+        export_to_csv(report, args.csv_dir)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()
 

--- a/test_production_report_cli.py
+++ b/test_production_report_cli.py
@@ -1,0 +1,77 @@
+import csv
+import json
+import sys
+from io import StringIO
+
+from production_report import generate_production_report, export_to_csv, main
+
+
+def _sample_events():
+    return [
+        {
+            "orderId": "A",
+            "workstation": "Cut",
+            "startTime": "2024-01-01T00:00:00Z",
+            "endTime": "2024-01-01T01:00:00Z",
+        },
+        {
+            "orderId": "A",
+            "workstation": "Print",
+            "startTime": "2024-01-01T01:00:00Z",
+            "endTime": "2024-01-01T03:00:00Z",
+        },
+        {
+            "orderId": "B",
+            "workstation": "Cut",
+            "startTime": "2024-01-01T02:00:00Z",
+            "endTime": "2024-01-01T04:00:00Z",
+        },
+    ]
+
+
+def _make_report():
+    events = _sample_events()
+    return generate_production_report(
+        events, "2024-01-01T00:00:00Z", "2024-01-02T00:00:00Z"
+    )
+
+
+def test_export_to_csv(tmp_path):
+    report = _make_report()
+    export_to_csv(report, tmp_path)
+
+    with open(tmp_path / "Summary.csv", newline="") as fh:
+        rows = list(csv.reader(fh))
+    assert rows[0] == ["Order ID", "Cut", "Print", "Order Total"]
+    assert rows[1] == ["A", "1.00", "2.00", "3.00"]
+    assert rows[2] == ["B", "2.00", "0.00", "2.00"]
+    assert rows[3] == ["Totals", "3.00", "2.00", "5.00"]
+
+    with open(tmp_path / "Details.csv", newline="") as fh:
+        drows = list(csv.reader(fh))
+    assert drows[0] == ["Order ID", "Workstation", "Start", "End", "Hours"]
+    assert len(drows) == 4
+    assert drows[1][0] == "A"
+
+
+def test_main_writes_csv(tmp_path):
+    events = _sample_events()
+    stdin = StringIO(json.dumps(events))
+    old_stdin = sys.stdin
+    try:
+        sys.stdin = stdin
+        main(
+            [
+                "--start",
+                "2024-01-01T00:00:00Z",
+                "--end",
+                "2024-01-02T00:00:00Z",
+                "--csv-dir",
+                str(tmp_path),
+            ]
+        )
+    finally:
+        sys.stdin = old_stdin
+
+    assert (tmp_path / "Summary.csv").exists()
+    assert (tmp_path / "Details.csv").exists()


### PR DESCRIPTION
## Summary
- add CSV and Google Sheet export helpers for production reports
- support command line interface for generating and exporting reports
- test CSV export and CLI behaviour

## Testing
- `pytest test_production_report_cli.py test_lead_time_report.py test_manage_html_report.py test_time_utils.py -q`
- `pytest test_YBS_CONTROL.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6899891012e8832d9a61421fd3d9df0a