### PR TITLE
feat: add production report export tab

### DIFF
--- a/production_report.py
+++ b/production_report.py
@@ -257,7 +257,7 @@ def export_to_sheets(report: Dict[str, object], sheet_id: str) -> None:
         try:
             ws = spreadsheet.worksheet(title)
             ws.clear()
-        except gspread.WorksheetNotFound:
+        except Exception:
             ws = spreadsheet.add_worksheet(title=title, rows=rows_len, cols=cols)
         ws.update("A5", [headers] + rows)
 


### PR DESCRIPTION
## Summary
- add Production Report tab with date range and destination selection
- wire UI to generate_production_report with CSV or Google Sheets export
- show status and error dialogs for report generation/export
- broaden Sheets export error handling
- add regression tests for new report export path

## Testing
- `python -m pytest test_generate_production_report.py -q`
- `python -m pytest test_lead_time_report.py -q`
- `python -m pytest test_manage_html_report.py -q`
- `python -m pytest test_production_report_cli.py -q`
- `python -m pytest test_production_report.py -q`
- `python -m pytest test_time_utils.py -q`
- `python -m pytest test_YBS_CONTROL.py::YBSControlTests::test_run_production_report_exports_csv -q`
- `python -m pytest test_YBS_CONTROL.py -q` *(process terminated: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_689a216e5080832d9ee4759a98a27d00