### PR TITLE
Validate date range in report utilities

### DIFF
--- a/lead_time_report.py
+++ b/lead_time_report.py
@@ -87,6 +87,8 @@ def main():
     args = parse_args()
     start_date = datetime.strptime(args.start, "%Y-%m-%d") if args.start else None
     end_date = datetime.strptime(args.end, "%Y-%m-%d") if args.end else None
+    if start_date and end_date and end_date < start_date:
+        raise argparse.ArgumentTypeError("--end must be on or after --start")
     rows = list(load_rows(args.csv_file))
     res = compute_lead_times(
         rows, start_date, end_date, show_breakdown=args.show_breakdown

--- a/manage_html_report.py
+++ b/manage_html_report.py
@@ -109,9 +109,11 @@ def write_report(results, path):
 
 def main():
     args = parse_args()
-    jobs = parse_manage_html(args.html_file)
     start = datetime.strptime(args.start, "%Y-%m-%d") if args.start else None
     end = datetime.strptime(args.end, "%Y-%m-%d") if args.end else None
+    if start and end and end < start:
+        raise argparse.ArgumentTypeError("--end must be on or after --start")
+    jobs = parse_manage_html(args.html_file)
     results = compute_lead_times(jobs, start, end)
     write_report(results, args.output)
     print(f"Report written to {args.output}")

--- a/test_lead_time_report.py
+++ b/test_lead_time_report.py
@@ -2,7 +2,10 @@ import unittest
 from datetime import datetime
 from io import StringIO
 from contextlib import redirect_stdout
+import sys
+import argparse
 
+import lead_time_report
 from lead_time_report import compute_lead_times, format_breakdown
 
 
@@ -45,6 +48,23 @@ class LeadTimeTests(unittest.TestCase):
         output = buf.getvalue()
         self.assertIn("Breakdown for job 1001 step print:", output)
         self.assertAlmostEqual(res["1001"][0]["hours"], 4)
+
+    def test_main_invalid_date_range(self):
+        argv = [
+            "lead_time_report.py",
+            "dummy.csv",
+            "--start",
+            "2024-01-02",
+            "--end",
+            "2024-01-01",
+        ]
+        old_argv = sys.argv
+        try:
+            sys.argv = argv
+            with self.assertRaises(argparse.ArgumentTypeError):
+                lead_time_report.main()
+        finally:
+            sys.argv = old_argv
 
 if __name__ == "__main__":
     unittest.main()

--- a/test_manage_html_report.py
+++ b/test_manage_html_report.py
@@ -2,7 +2,10 @@ import os
 import tempfile
 import unittest
 from datetime import datetime
+import sys
+import argparse
 
+import manage_html_report
 from manage_html_report import compute_lead_times, parse_manage_html
 
 SAMPLE_HTML = """
@@ -99,6 +102,23 @@ class ManageHTMLTests(unittest.TestCase):
         start = datetime(2025, 7, 23)
         results = compute_lead_times(jobs, start_date=start)
         self.assertEqual(len(results["1001"]), 0)
+
+    def test_main_invalid_date_range(self):
+        argv = [
+            "manage_html_report.py",
+            "dummy.html",
+            "--start",
+            "2025-07-24",
+            "--end",
+            "2025-07-23",
+        ]
+        old_argv = sys.argv
+        try:
+            sys.argv = argv
+            with self.assertRaises(argparse.ArgumentTypeError):
+                manage_html_report.main()
+        finally:
+            sys.argv = old_argv
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure `--end` is not before `--start` in `lead_time_report` and `manage_html_report`
- add unit tests covering invalid date ranges

## Testing
- `pytest test_lead_time_report.py test_manage_html_report.py`


------
https://chatgpt.com/codex/tasks/task_e_689cf4c9cab0832db3fb25a43868f230