### PR TITLE
Rename step key to workstation across reports

### DIFF
--- a/YBS_CONTROL.py
+++ b/YBS_CONTROL.py
@@ -551,7 +551,7 @@ class OrderScraperApp:
                 "INSERT INTO lead_times(order_number, workstation, start, end, hours) VALUES (?, ?, ?, ?, ?)",
                 (
                     order_number,
-                    item["step"],
+                    item["workstation"],
                     item["start"].isoformat(sep=" "),
                     item["end"].isoformat(sep=" "),
                     item["hours"],
@@ -586,7 +586,7 @@ class OrderScraperApp:
         cur.execute(query, params)
         rows = [
             {
-                "step": r[0],
+                "workstation": r[0],
                 "start": datetime.fromisoformat(r[1]),
                 "end": datetime.fromisoformat(r[2]),
                 "hours": r[3],
@@ -751,14 +751,14 @@ class OrderScraperApp:
                     "INSERT INTO lead_times(order_number, workstation, start, end, hours) VALUES (?, ?, ?, ?, ?)",
                     (
                         order_number,
-                        item["step"],
+                        item["workstation"],
                         item["start"].isoformat(sep=" "),
                         item["end"].isoformat(sep=" "),
                         item["hours"],
                     ),
                 )
             self.db.commit()
-        row_map = {r["step"]: r for r in rows}
+        row_map = {r["workstation"]: r for r in rows}
         self.report_tree.delete(*self.report_tree.get_children())
         total = 0.0
         for idx, (name, ts) in enumerate(steps):

--- a/manage_html_report.py
+++ b/manage_html_report.py
@@ -79,7 +79,7 @@ def compute_lead_times(jobs, start_date=None, end_date=None):
             hours = delta.total_seconds() / 3600.0
             results[job].append(
                 {
-                    "step": next_name,
+                    "workstation": next_name,
                     "hours": hours,
                     "start": start,
                     "end": end,
@@ -99,7 +99,7 @@ def write_report(results, path):
                 writer.writerow(
                     {
                         "job_number": job,
-                        "workstation": step["step"],
+                        "workstation": step["workstation"],
                         "hours_in_queue": f"{step['hours']:.2f}",
                         "start": step["start"].isoformat(sep=" "),
                         "end": step["end"].isoformat(sep=" "),

--- a/readme.md
+++ b/readme.md
@@ -87,7 +87,7 @@ Open an issue or contact Valis.
 
 Lead Time Report
 ----------------
-The `lead_time_report.py` script generates a CSV report showing how long jobs spend in each workstation queue using a CSV export. The CSV must contain the columns `job_number`, `step`, `time_in`, and `time_out` where the timestamps are in `YYYY-MM-DD HH:MM:SS` format. Usage:
+The `lead_time_report.py` script generates a CSV report showing how long jobs spend in each workstation queue using a CSV export. The CSV must contain the columns `job_number`, `workstation`, `time_in`, and `time_out` where the timestamps are in `YYYY-MM-DD HH:MM:SS` format. Usage:
 
 ```bash
 python lead_time_report.py data.csv --start 2024-01-01 --end 2024-01-31 --output report.csv

--- a/test_YBS_CONTROL.py
+++ b/test_YBS_CONTROL.py
@@ -203,7 +203,7 @@ class YBSControlTests(unittest.TestCase):
         self.app.analytics_job_var = SimpleVar("")
         self.app.order_rows = [("123", "ACME", "Running", "High")]
         self.app.load_steps = MagicMock(return_value=[("Cutting", datetime(2024, 1, 1, 8, 0)), ("Welding", datetime(2024, 1, 1, 12, 0))])
-        mock_compute.return_value = {"123": [{"hours": 4, "step": "Welding"}]}
+        mock_compute.return_value = {"123": [{"hours": 4, "workstation": "Welding"}]}
         OrderScraperApp.update_analytics_chart(self.app)
         mock_compute.assert_called_once()
         self.app.analytics_ax.bar.assert_called_once()

--- a/test_lead_time_report.py
+++ b/test_lead_time_report.py
@@ -14,13 +14,13 @@ class LeadTimeTests(unittest.TestCase):
         rows = [
             {
                 "job_number": "1001",
-                "step": "print",
+                "workstation": "print",
                 "time_in": datetime(2024, 1, 2, 8, 0),
                 "time_out": datetime(2024, 1, 2, 12, 0),
             },
             {
                 "job_number": "1001",
-                "step": "laminate",
+                "workstation": "laminate",
                 "time_in": datetime(2024, 1, 3, 8, 0),
                 "time_out": datetime(2024, 1, 3, 10, 0),
             },
@@ -34,7 +34,7 @@ class LeadTimeTests(unittest.TestCase):
         rows = [
             {
                 "job_number": "1001",
-                "step": "print",
+                "workstation": "print",
                 "time_in": datetime(2024, 1, 2, 8, 0),
                 "time_out": datetime(2024, 1, 2, 12, 0),
             }
@@ -44,9 +44,13 @@ class LeadTimeTests(unittest.TestCase):
             res, breakdowns = compute_lead_times(rows, show_breakdown=True)
             for job, entries in breakdowns.items():
                 for entry in entries:
-                    print(format_breakdown(job, entry["step"], entry["segments"]))
+                    print(
+                        format_breakdown(
+                            job, entry["workstation"], entry["segments"]
+                        )
+                    )
         output = buf.getvalue()
-        self.assertIn("Breakdown for job 1001 step print:", output)
+        self.assertIn("Breakdown for job 1001 workstation print:", output)
         self.assertAlmostEqual(res["1001"][0]["hours"], 4)
 
     def test_main_invalid_date_range(self):


### PR DESCRIPTION
## Summary
- rename lead time results key from `step` to `workstation`
- update HTML and CSV report writers to use `workstation`
- adjust tests and docs for `workstation` field

## Testing
- `pytest test_lead_time_report.py -q`
- `pytest test_manage_html_report.py -q`
- `pytest test_YBS_CONTROL.py -q` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_689cf89e3dc0832d866263ea60c9bf56