### PR TITLE
Add realtime lead time report generation

### DIFF
--- a/manage_html_report.py
+++ b/manage_html_report.py
@@ -88,6 +88,31 @@ def compute_lead_times(jobs, start_date=None, end_date=None):
     return results
 
 
+def generate_realtime_report(jobs, start_date=None, end_date=None):
+    """Generate a realtime style report of lead times.
+
+    The returned value is a list of tuples ordered the same way the jobs appear
+    in ``manage.html``. Each tuple contains ``(order, workstation, start, end,
+    hours)`` where ``start`` and ``end`` are ``datetime`` objects and ``hours``
+    is the number of business hours between them.
+    """
+
+    lead_times = compute_lead_times(jobs, start_date, end_date)
+    report = []
+    for order in jobs:  # preserve realtime ordering
+        for step in lead_times.get(order, []):
+            report.append(
+                (
+                    order,
+                    step["workstation"],
+                    step["start"],
+                    step["end"],
+                    step["hours"],
+                )
+            )
+    return report
+
+
 def write_report(results, path):
     """Write lead time data to ``path`` including timestamps."""
     with open(path, "w", newline="") as f:

--- a/test_manage_html_report.py
+++ b/test_manage_html_report.py
@@ -6,7 +6,11 @@ import sys
 import argparse
 
 import manage_html_report
-from manage_html_report import compute_lead_times, parse_manage_html
+from manage_html_report import (
+    compute_lead_times,
+    parse_manage_html,
+    generate_realtime_report,
+)
 
 SAMPLE_HTML = """
 <tbody id="table">
@@ -94,8 +98,19 @@ class ManageHTMLTests(unittest.TestCase):
         results = compute_lead_times(jobs)
         entry = results["1001"][0]
         self.assertAlmostEqual(entry["hours"], 13.5)
-        self.assertIsInstance(entry["start"], datetime)
-        self.assertIsInstance(entry["end"], datetime)
+        self.assertEqual(entry["start"], datetime(2025, 7, 22, 10, 0))
+        self.assertEqual(entry["end"], datetime(2025, 7, 23, 15, 0))
+
+    def test_generate_realtime_report(self):
+        jobs = parse_manage_html(self.tmp_path)
+        report = generate_realtime_report(jobs)
+        self.assertEqual(len(report), 1)
+        order, workstation, start, end, hours = report[0]
+        self.assertEqual(order, "1001")
+        self.assertEqual(workstation, "Indigo")
+        self.assertEqual(start, datetime(2025, 7, 22, 10, 0))
+        self.assertEqual(end, datetime(2025, 7, 23, 15, 0))
+        self.assertAlmostEqual(hours, 13.5)
 
     def test_compute_lead_times_date_range(self):
         jobs = parse_manage_html(self.tmp_path)


### PR DESCRIPTION
## Summary
- expose start/end timestamps in lead time calculations
- add `generate_realtime_report` to flatten lead time data in realtime order
- cover realtime report ordering and timestamps in unit tests

## Testing
- `pytest test_manage_html_report.py::ManageHTMLTests::test_generate_realtime_report -q`
- `pytest -q` *(fails: required manual interrupt after tests completed)*

------
https://chatgpt.com/codex/tasks/task_e_689d036418b4832d962404abdaf6cbd2