### PR TITLE
Add realtime report writer and tests

### DIFF
--- a/manage_html_report.py
+++ b/manage_html_report.py
@@ -113,6 +113,54 @@ def generate_realtime_report(jobs, start_date=None, end_date=None):
     return report
 
 
+def write_realtime_report(report, csv_path, html_path):
+    """Write a realtime lead time report to CSV and HTML.
+
+    ``report`` should be a sequence as returned by
+    :func:`generate_realtime_report`. Rows are sorted chronologically by the
+    ``start`` timestamp. ``csv_path`` and ``html_path`` specify output file
+    locations for the CSV data and HTML table respectively.
+    """
+
+    # sort by start time to ensure chronological order
+    rows = sorted(report, key=lambda r: r[2])
+    headers = ["job_number", "workstation", "start", "end", "hours_in_queue"]
+
+    # write CSV output
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(headers)
+        for job, workstation, start, end, hours in rows:
+            writer.writerow(
+                [
+                    job,
+                    workstation,
+                    start.strftime(HTML_DATE_FORMAT),
+                    end.strftime(HTML_DATE_FORMAT),
+                    f"{hours:.2f}",
+                ]
+            )
+
+    # build HTML table
+    html_lines = ["<table>", "<thead><tr>"]
+    for h in headers:
+        html_lines.append(f"<th>{h}</th>")
+    html_lines.extend(["</tr></thead>", "<tbody>"])
+    for job, workstation, start, end, hours in rows:
+        html_lines.append(
+            "<tr>"
+            f"<td>{job}</td>"
+            f"<td>{workstation}</td>"
+            f"<td>{start.strftime(HTML_DATE_FORMAT)}</td>"
+            f"<td>{end.strftime(HTML_DATE_FORMAT)}</td>"
+            f"<td>{hours:.2f}</td>"
+            "</tr>"
+        )
+    html_lines.extend(["</tbody>", "</table>"])
+    with open(html_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(html_lines))
+
+
 def write_report(results, path):
     """Write lead time data to ``path`` including timestamps."""
     with open(path, "w", newline="") as f:

--- a/test_manage_html_report.py
+++ b/test_manage_html_report.py
@@ -4,12 +4,16 @@ import unittest
 from datetime import datetime
 import sys
 import argparse
+import csv
+
+from bs4 import BeautifulSoup
 
 import manage_html_report
 from manage_html_report import (
     compute_lead_times,
     parse_manage_html,
     generate_realtime_report,
+    write_realtime_report,
 )
 
 SAMPLE_HTML = """
@@ -39,6 +43,33 @@ SAMPLE_HTML_TEMPLATE = """
 <ul class="workplaces">
 <li><p><span class="circle"></span>Step1</p><p class="np">07/22/25 10:00</p></li>
 <li class="active_ws"><p><span class="circle"></span>Step2</p><p class="np">&nbsp;</p></li>
+</ul>
+</td>
+</tr>
+</tbody>
+"""
+
+SAMPLE_HTML_MULTI = """
+<tbody id="table">
+<tr data-id="1">
+<td class="move"><p>YBS 1001</p></td>
+<td></td>
+<td></td>
+<td>
+<ul class="workplaces">
+<li><p><span class="circle"></span>Prep</p><p class="np">07/22/25 10:00</p></li>
+<li><p><span class="circle"></span>Print</p><p class="np">07/22/25 11:00</p></li>
+</ul>
+</td>
+</tr>
+<tr data-id="2">
+<td class="move"><p>YBS 1002</p></td>
+<td></td>
+<td></td>
+<td>
+<ul class="workplaces">
+<li><p><span class="circle"></span>Prep</p><p class="np">07/21/25 09:00</p></li>
+<li><p><span class="circle"></span>Print</p><p class="np">07/21/25 10:00</p></li>
 </ul>
 </td>
 </tr>
@@ -111,6 +142,50 @@ class ManageHTMLTests(unittest.TestCase):
         self.assertEqual(start, datetime(2025, 7, 22, 10, 0))
         self.assertEqual(end, datetime(2025, 7, 23, 15, 0))
         self.assertAlmostEqual(hours, 13.5)
+
+    def test_write_realtime_report(self):
+        with tempfile.NamedTemporaryFile("w+", delete=False, suffix=".html") as tmp:
+            tmp.write(SAMPLE_HTML_MULTI)
+            html_path = tmp.name
+
+        jobs = parse_manage_html(html_path)
+        report = generate_realtime_report(jobs)
+        csv_fd, csv_path = tempfile.mkstemp(suffix=".csv")
+        html_fd, out_html_path = tempfile.mkstemp(suffix=".html")
+        os.close(csv_fd)
+        os.close(html_fd)
+
+        try:
+            write_realtime_report(report, csv_path, out_html_path)
+
+            # verify CSV output
+            with open(csv_path, newline="") as f:
+                rows = list(csv.reader(f))
+            self.assertEqual(
+                rows[0],
+                ["job_number", "workstation", "start", "end", "hours_in_queue"],
+            )
+            # chronological order (job 1002 starts earlier than 1001)
+            self.assertEqual(rows[1][0], "1002")
+            self.assertEqual(rows[2][0], "1001")
+            # date formatting
+            datetime.strptime(rows[1][2], manage_html_report.HTML_DATE_FORMAT)
+            datetime.strptime(rows[1][3], manage_html_report.HTML_DATE_FORMAT)
+
+            # verify HTML output
+            with open(out_html_path, encoding="utf-8") as f:
+                soup = BeautifulSoup(f, "html.parser")
+            headers = [th.get_text() for th in soup.select("thead tr th")]
+            self.assertEqual(
+                headers,
+                ["job_number", "workstation", "start", "end", "hours_in_queue"],
+            )
+            first_row = [td.get_text() for td in soup.select("tbody tr")[0].find_all("td")]
+            self.assertEqual(first_row[0], "1002")
+        finally:
+            os.remove(html_path)
+            os.remove(csv_path)
+            os.remove(out_html_path)
 
     def test_compute_lead_times_date_range(self):
         jobs = parse_manage_html(self.tmp_path)


### PR DESCRIPTION
## Summary
- add `write_realtime_report` to output sorted CSV and HTML tables
- ensure timestamps use `HTML_DATE_FORMAT`
- cover CSV/HTML ordering and formatting with new tests

## Testing
- `python -m pytest test_manage_html_report.py::ManageHTMLTests::test_write_realtime_report -q`
- `python -m pytest test_manage_html_report.py test_lead_time_report.py test_production_report.py test_generate_production_report.py test_production_report_cli.py test_time_utils.py -q` *(fails: `test_export_to_sheets`, `test_timezone_conversion_and_storage`)*

------
https://chatgpt.com/codex/tasks/task_e_689d08019bb0832d93f74351774e0310