### PR TITLE
Fix date range report column mapping

### DIFF
--- a/YBS_CONTROL.py
+++ b/YBS_CONTROL.py
@@ -1233,7 +1233,14 @@ class OrderScraperApp:
                 "",
                 "end",
                 text=r["order"],
-                values=(r["customer"], r.get("status", ""), f"{r['hours']:.2f}", "", ""),
+                values=(
+                    r["customer"],
+                    "",
+                    "",
+                    "",
+                    f"{r['hours']:.2f}",
+                    r.get("status", ""),
+                ),
                 tags=tags,
                 open=False,
             )
@@ -1242,14 +1249,21 @@ class OrderScraperApp:
                     parent,
                     "end",
                     text="",
-                    values=("", ws["workstation"], f"{ws['hours']:.2f}", ws["start"], ws["end"]),
+                    values=(
+                        "",
+                        ws["workstation"],
+                        ws["start"],
+                        ws["end"],
+                        f"{ws['hours']:.2f}",
+                        "",
+                    ),
                 )
             total += r["hours"]
         self.date_tree.insert(
             "",
             "end",
             text="TOTAL",
-            values=("", "", f"{total:.2f}", "", ""),
+            values=("", "", "", "", f"{total:.2f}", ""),
             tags=("total",),
         )
 

--- a/test_YBS_CONTROL.py
+++ b/test_YBS_CONTROL.py
@@ -445,13 +445,13 @@ class YBSControlTests(unittest.TestCase):
         self.assertFalse(insert_calls[0].kwargs["open"])
         self.assertEqual(
             insert_calls[0].kwargs["values"],
-            ("A", "Completed", "2.00", "", ""),
+            ("A", "", "", "", "2.00", "Completed"),
         )
 
         # child row for order 1
         self.assertEqual(
             insert_calls[1].kwargs["values"],
-            ("", "WS1", "2.00", "2024-01-01", "2024-01-01"),
+            ("", "WS1", "2024-01-01", "2024-01-01", "2.00", ""),
         )
 
         # parent row for order 2 (in progress)
@@ -459,21 +459,21 @@ class YBSControlTests(unittest.TestCase):
         self.assertFalse(insert_calls[2].kwargs["open"])
         self.assertEqual(
             insert_calls[2].kwargs["values"],
-            ("B", "In Progress", "3.00", "", ""),
+            ("B", "", "", "", "3.00", "In Progress"),
         )
         self.assertIn("inprogress", insert_calls[2].kwargs["tags"])
 
         # child row for order 2
         self.assertEqual(
             insert_calls[3].kwargs["values"],
-            ("", "WS2", "3.00", "2024-01-02", ""),
+            ("", "WS2", "2024-01-02", "", "3.00", ""),
         )
 
         # total row
         self.assertEqual(insert_calls[4].kwargs["text"], "TOTAL")
         self.assertEqual(
             insert_calls[4].kwargs["values"],
-            ("", "", "5.00", "", ""),
+            ("", "", "", "", "5.00", ""),
         )
 
         # tag configured for in-progress orders
@@ -541,9 +541,12 @@ class YBSControlTests(unittest.TestCase):
         self.app.run_date_range_report()
         insert_calls = self.app.date_tree.insert.call_args_list
         values_list = [call.kwargs["values"] for call in insert_calls]
-        self.assertIn(("", "Print File", "0.00", "", "2024-01-01"), values_list)
-        self.assertIn(("", "Shipping", "0.00", "2024-01-02", ""), values_list)
-        self.assertEqual(insert_calls[0].kwargs["values"], ("A", "In Progress", "1.00", "", ""))
+        self.assertIn(("", "Print File", "", "2024-01-01", "0.00", ""), values_list)
+        self.assertIn(("", "Shipping", "2024-01-02", "", "0.00", ""), values_list)
+        self.assertEqual(
+            insert_calls[0].kwargs["values"],
+            ("A", "", "", "", "1.00", "In Progress"),
+        )
 
     def test_populate_date_range_table_inserts_parent_and_child_rows(self):
         rows = [


### PR DESCRIPTION
## Summary
- Correct Date Range report table to display Start, End, and Hours in proper columns
- Update tests for new column order

## Testing
- `pytest test_YBS_CONTROL.py::YBSControlTests::test_run_date_range_report_populates_table_and_summary -q`
- `pytest test_YBS_CONTROL.py::YBSControlTests::test_run_date_range_report_adds_missing_steps_and_sets_in_progress -q`
- `pytest test_YBS_CONTROL.py::YBSControlTests::test_populate_date_range_table_inserts_parent_and_child_rows -q`
- `pytest -q` *(killed: environment issue)*

------
https://chatgpt.com/codex/tasks/task_e_689d53c5927c832db020fa9c839b4156