### PR TITLE
Fix company info extraction from orders table

### DIFF
--- a/YBS_CONTROL.py
+++ b/YBS_CONTROL.py
@@ -540,10 +540,10 @@ class OrderScraperApp:
                         if not order_num and re.search(r"\d", part):
                             match = re.search(r"([A-Za-z0-9_-]+)$", part)
                             order_num = match.group(1) if match else re.sub(r"[^A-Za-z0-9_-]", "", part)
-                        elif not company:
+                        elif not company and re.search(r"[A-Za-z]", part):
                             company = part
 
-                    if not company and len(tds) > 1:
+                    if (not company or company == "?") and len(tds) > 1:
                         for text in tds[1].stripped_strings:
                             company = text
                             break

--- a/YBS_CONTROL.py
+++ b/YBS_CONTROL.py
@@ -543,6 +543,11 @@ class OrderScraperApp:
                         elif not company:
                             company = part
 
+                    if not company and len(tds) > 1:
+                        for text in tds[1].stripped_strings:
+                            company = text
+                            break
+
                     # Remaining columns contain status and priority, but the
                     # page includes spacer cells.  Use indexes 2 and 4 rather
                     # than 1 and 3 to skip those spacers when present.

--- a/YBS_CONTROL.py
+++ b/YBS_CONTROL.py
@@ -376,7 +376,7 @@ class OrderScraperApp:
         table_frame.grid(row=2, column=0, columnspan=7, sticky="nsew", padx=10, pady=10)
 
         columns = (
-            "customer",
+            "company",
             "workstation",
             "start",
             "end",
@@ -394,7 +394,7 @@ class OrderScraperApp:
         )
         self.date_tree.column("#0", anchor="center")
         headings = [
-            "Customer",
+            "Company",
             "Workstation",
             "Start",
             "End",
@@ -1215,7 +1215,7 @@ class OrderScraperApp:
             rows.append(
                 {
                     "order": order,
-                    "customer": company,
+                    "company": company,
                     "workstation": ws,
                     "hours": hours or 0.0,
                     "status": status,
@@ -1239,7 +1239,7 @@ class OrderScraperApp:
                 "end",
                 text=r["order"],
                 values=(
-                    r["customer"],
+                    r["company"],
                     "",
                     "",
                     "",
@@ -1300,7 +1300,7 @@ class OrderScraperApp:
                 order,
                 {
                     "order": order,
-                    "customer": r.get("customer", ""),
+                    "company": r.get("company", ""),
                     "hours": 0.0,
                     "workstations": [],
                     "status": "Completed",
@@ -1349,7 +1349,7 @@ class OrderScraperApp:
                     raw_rows.append(
                         {
                             "order": order,
-                            "customer": g.get("customer", ""),
+                            "company": g.get("company", ""),
                             "workstation": step_name,
                             "hours": hours,
                             "start": start_str,
@@ -1389,7 +1389,7 @@ class OrderScraperApp:
             writer = csv.writer(f)
             writer.writerow([
                 "Order",
-                "Customer",
+                "Company",
                 "Workstation",
                 "Start",
                 "End",
@@ -1399,7 +1399,7 @@ class OrderScraperApp:
             for r in self.date_range_rows:
                 writer.writerow([
                     r["order"],
-                    r.get("customer", ""),
+                    r.get("company", ""),
                     "",
                     "",
                     "",
@@ -1428,13 +1428,13 @@ class OrderScraperApp:
                 r
                 for r in self.date_range_rows
                 if term in str(r.get("order", "")).lower()
-                or term in str(r.get("customer", "")).lower()
+                or term in str(r.get("company", "")).lower()
             ]
             raw_rows = [
                 r
                 for r in self.raw_date_range_rows
                 if term in str(r.get("order", "")).lower()
-                or term in str(r.get("customer", "")).lower()
+                or term in str(r.get("company", "")).lower()
             ]
         self.filtered_date_range_rows = rows
         self.filtered_raw_date_range_rows = raw_rows
@@ -1444,7 +1444,7 @@ class OrderScraperApp:
     def sort_date_range_table(self, column, reverse=False):
         key_funcs = {
             "order": lambda r: r["order"],
-            "customer": lambda r: r["customer"],
+            "company": lambda r: r["company"],
             "hours": lambda r: r["hours"],
         }
         if column not in key_funcs:

--- a/test_YBS_CONTROL.py
+++ b/test_YBS_CONTROL.py
@@ -135,6 +135,30 @@ class YBSControlTests(unittest.TestCase):
         args, kwargs = self.app.orders_tree.insert.call_args
         self.assertEqual(kwargs["values"], ("12345", "ACME Corp", "Running", "High"))
 
+    @patch("YBS_CONTROL.messagebox")
+    def test_parse_company_and_order_from_separate_cells(self, mock_messagebox):
+        html = (
+            "<table><tbody id='table'>"
+            "<tr>"
+            "<td>YBS 35264<ul class='workplaces'></ul></td>"
+            "<td class='details cboxElement'><p>Velocity Production and Packaging</p><p>Hydration Heroes Mini Kit</p></td>"
+            "<td></td>"
+            "<td></td>"
+            "<td><input value=''/></td>"
+            "</tr>"
+            "</tbody></table>"
+        )
+        mock_response = MagicMock()
+        mock_response.text = html
+        self.app.session.get.return_value = mock_response
+        self.app.get_orders()
+        self.app.orders_tree.insert.assert_called_once()
+        args, kwargs = self.app.orders_tree.insert.call_args
+        self.assertEqual(
+            kwargs["values"],
+            ("35264", "Velocity Production and Packaging", "", ""),
+        )
+
     def test_show_report_displays_all_workstations(self):
         self.app.start_date_var = SimpleVar("")
         self.app.end_date_var = SimpleVar("")

--- a/test_YBS_CONTROL.py
+++ b/test_YBS_CONTROL.py
@@ -443,7 +443,7 @@ class YBSControlTests(unittest.TestCase):
         rows = [
             {
                 "order": "1",
-                "customer": "A",
+                "company": "A",
                 "workstation": "WS1",
                 "hours": 2.0,
                 "start": "2024-01-01",
@@ -451,7 +451,7 @@ class YBSControlTests(unittest.TestCase):
             },
             {
                 "order": "2",
-                "customer": "B",
+                "company": "B",
                 "workstation": "WS2",
                 "hours": 3.0,
                 "start": "2024-01-02",
@@ -511,7 +511,7 @@ class YBSControlTests(unittest.TestCase):
         rows = [
             {
                 "order": "1",
-                "customer": "A",
+                "company": "A",
                 "workstation": "WS1",
                 "hours": 1.0,
                 "start": "2024-01-01",
@@ -519,7 +519,7 @@ class YBSControlTests(unittest.TestCase):
             },
             {
                 "order": "1",
-                "customer": "A",
+                "company": "A",
                 "workstation": "WS2",
                 "hours": 2.0,
                 "start": "2024-01-01",
@@ -550,7 +550,7 @@ class YBSControlTests(unittest.TestCase):
         rows = [
             {
                 "order": "1",
-                "customer": "A",
+                "company": "A",
                 "workstation": "Cutting",
                 "hours": 1.0,
                 "start": "2024-01-01",
@@ -578,7 +578,7 @@ class YBSControlTests(unittest.TestCase):
         rows = [
             {
                 "order": "1",
-                "customer": "A",
+                "company": "A",
                 "workstation": "Shipping",
                 "hours": 1.0,
                 "start": "2024-01-02",
@@ -586,7 +586,7 @@ class YBSControlTests(unittest.TestCase):
             },
             {
                 "order": "1",
-                "customer": "A",
+                "company": "A",
                 "workstation": "Cutting",
                 "hours": 2.0,
                 "start": "2024-01-01",
@@ -609,7 +609,7 @@ class YBSControlTests(unittest.TestCase):
         rows = [
             {
                 "order": "1",
-                "customer": "Cust",
+                "company": "Cust",
                 "hours": 3.0,
                 "status": "Completed",
                 "workstations": [
@@ -659,7 +659,7 @@ class YBSControlTests(unittest.TestCase):
         rows = [
             {
                 "order": "1",
-                "customer": "Alpha",
+                "company": "Alpha",
                 "workstation": "WS1",
                 "hours": 1.0,
                 "start": "2024-01-01",
@@ -667,7 +667,7 @@ class YBSControlTests(unittest.TestCase):
             },
             {
                 "order": "2",
-                "customer": "Beta",
+                "company": "Beta",
                 "workstation": "WS2",
                 "hours": 2.0,
                 "start": "2024-01-02",
@@ -675,7 +675,7 @@ class YBSControlTests(unittest.TestCase):
             },
             {
                 "order": "3",
-                "customer": "AlphaBeta",
+                "company": "AlphaBeta",
                 "workstation": "WS3",
                 "hours": 3.0,
                 "start": "2024-01-03",

--- a/test_YBS_CONTROL.py
+++ b/test_YBS_CONTROL.py
@@ -159,6 +159,30 @@ class YBSControlTests(unittest.TestCase):
             ("35264", "Velocity Production and Packaging", "", ""),
         )
 
+    @patch("YBS_CONTROL.messagebox")
+    def test_parse_company_skips_placeholder_in_first_cell(self, mock_messagebox):
+        html = (
+            "<table><tbody id='table'>"
+            "<tr>"
+            "<td>YBS 35264<p>?</p><ul class='workplaces'></ul></td>"
+            "<td class='details cboxElement'><p>Velocity Production and Packaging</p><p>Hydration Heroes Mini Kit</p></td>"
+            "<td></td>"
+            "<td></td>"
+            "<td><input value=''/></td>"
+            "</tr>"
+            "</tbody></table>"
+        )
+        mock_response = MagicMock()
+        mock_response.text = html
+        self.app.session.get.return_value = mock_response
+        self.app.get_orders()
+        self.app.orders_tree.insert.assert_called_once()
+        args, kwargs = self.app.orders_tree.insert.call_args
+        self.assertEqual(
+            kwargs["values"],
+            ("35264", "Velocity Production and Packaging", "", ""),
+        )
+
     def test_show_report_displays_all_workstations(self):
         self.app.start_date_var = SimpleVar("")
         self.app.end_date_var = SimpleVar("")


### PR DESCRIPTION
## Summary
- Handle company names stored in a separate table cell when scraping orders
- Test scraping for company names in separate order table cells

## Testing
- `pytest test_YBS_CONTROL.py::YBSControlTests::test_parse_company_and_order_from_separate_cells -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d62e4bd74832d979dce2166f6e4c1