### PR TITLE
Handle queue parsing errors

### DIFF
--- a/test_YBS_CONTROL.py
+++ b/test_YBS_CONTROL.py
@@ -123,6 +123,12 @@ class YBSControlTests(unittest.TestCase):
         self.assertEqual(row[0], "Print File")
         self.assertTrue(row[1])
 
+    def test_process_queue_html_logs_error_on_malformed_html(self):
+        with patch("YBS_CONTROL.BeautifulSoup", side_effect=ValueError("boom")):
+            with self.assertLogs("YBS_CONTROL", level="ERROR") as cm:
+                self.app._process_queue_html("<bad>")
+        self.assertTrue(any("Error processing queue HTML" in msg for msg in cm.output))
+
     @patch("YBS_CONTROL.messagebox")
     def test_parse_company_and_order_from_same_cell(self, mock_messagebox):
         html = (


### PR DESCRIPTION
## Summary
- wrap queue processing in a try/except block that logs exceptions so malformed HTML doesn't crash the scraper
- guard get_orders so the orders page still processes even if queue parsing fails
- add regression test ensuring malformed queue HTML logs an error instead of crashing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e71afee70832dabbbad6ce2cea3dc