### PR TITLE
feat: add YBS client service layer

### DIFF
--- a/services/ybs_client.py
+++ b/services/ybs_client.py
@@ -1,0 +1,51 @@
+import os
+import requests
+
+LOGIN_URL = "https://www.ybsnow.com/index.php"
+ORDERS_URL = "https://www.ybsnow.com/manage.html"
+QUEUE_URL = "https://www.ybsnow.com/queue.html"
+
+def login(session, credentials):
+    """Attempt to log into YBS.
+
+    Args:
+        session: requests.Session used for HTTP requests.
+        credentials: dict containing 'username', 'password', and optional
+            'login_url' and 'orders_url'.
+
+    Returns:
+        dict with keys ``success`` and ``response``. ``success`` is ``True``
+        if the login appears successful based on the response HTML.
+
+    Raises:
+        requests.RequestException: if the request fails.
+    """
+    login_url = credentials.get("login_url", LOGIN_URL)
+    orders_url = credentials.get("orders_url", ORDERS_URL)
+    data = {
+        "email": credentials.get("username", ""),
+        "password": credentials.get("password", ""),
+        "action": "signin",
+    }
+    resp = session.post(login_url, data=data, timeout=10)
+    orders_page = os.path.basename(orders_url).lower()
+    success = "logout" in resp.text.lower() or orders_page in resp.text.lower()
+    return {"success": success, "response": resp}
+
+def fetch_orders(session, orders_url=ORDERS_URL, queue_url=QUEUE_URL):
+    """Fetch the orders and queue pages.
+
+    Args:
+        session: requests.Session used for HTTP requests.
+        orders_url: URL of the orders page.
+        queue_url: URL of the queue page.
+
+    Returns:
+        dict with ``orders_html`` and ``queue_html`` keys.
+
+    Raises:
+        requests.RequestException: if a request fails.
+    """
+    resp_orders = session.get(orders_url, timeout=10)
+    resp_queue = session.get(queue_url, timeout=10)
+    return {"orders_html": resp_orders.text, "queue_html": resp_queue.text}

--- a/test_YBS_CONTROL.py
+++ b/test_YBS_CONTROL.py
@@ -349,32 +349,30 @@ class YBSControlTests(unittest.TestCase):
         self.app.save_config.assert_called_once()
 
     @patch("ui.order_app.messagebox")
-    def test_handle_login_response_triggers_get_orders_only_on_success(self, mock_messagebox):
+    def test_handle_login_result_triggers_get_orders_only_on_success(self, mock_messagebox):
         self.app.get_orders = MagicMock()
         self.app.refresh_entry = MagicMock()
         self.app.refresh_button = MagicMock()
         self.app.schedule_auto_refresh = MagicMock()
-        mock_resp = MagicMock()
 
         # simulate login failure
-        mock_resp.text = "login failed"
-        self.app._handle_login_response(mock_resp)
+        result = {"success": False}
+        self.app._handle_login_result(result)
         self.app.get_orders.assert_not_called()
 
         # simulate login success
-        mock_resp.text = "logout"
-        self.app._handle_login_response(mock_resp)
+        result = {"success": True}
+        self.app._handle_login_result(result)
         self.app.get_orders.assert_called_once()
 
     @patch("ui.order_app.messagebox")
-    def test_handle_login_response_silent(self, mock_messagebox):
+    def test_handle_login_result_silent(self, mock_messagebox):
         self.app.get_orders = MagicMock()
         self.app.refresh_entry = MagicMock()
         self.app.refresh_button = MagicMock()
         self.app.schedule_auto_refresh = MagicMock()
-        mock_resp = MagicMock()
-        mock_resp.text = "logout"
-        self.app._handle_login_response(mock_resp, silent=True)
+        result = {"success": True}
+        self.app._handle_login_result(result, silent=True)
         mock_messagebox.showinfo.assert_not_called()
         self.app.get_orders.assert_called_once()
 


### PR DESCRIPTION
## Summary
- add dedicated `services.ybs_client` with reusable login and order-fetch helpers
- route `OrderScraperApp` network calls through service layer and return structured results
- adjust tests for new login result structure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689eb6a067a0832da5f2f9658e5b5780