### PR TITLE
Refactor HTML parsing into dedicated module

### DIFF
--- a/parsers/__init__.py
+++ b/parsers/__init__.py
@@ -1,0 +1,3 @@
+from .manage_html import parse_orders, parse_queue, Order, Step
+
+__all__ = ["parse_orders", "parse_queue", "Order", "Step"]

--- a/parsers/manage_html.py
+++ b/parsers/manage_html.py
@@ -1,0 +1,99 @@
+"""HTML parsers for order and queue pages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Optional, Set
+import logging
+import re
+
+from bs4 import BeautifulSoup
+
+logger = logging.getLogger(__name__)
+
+HTML_DATE_FORMAT = "%m/%d/%y %H:%M"
+
+
+@dataclass
+class Step:
+    name: str
+    timestamp: Optional[datetime]
+
+
+@dataclass
+class Order:
+    number: str
+    company: str
+    status: str
+    priority: str
+    steps: List[Step]
+
+
+def parse_orders(html: str) -> List[Order]:
+    """Parse an orders HTML page into ``Order`` objects."""
+    soup = BeautifulSoup(html, "html.parser")
+    tbody = soup.find("tbody", id="table")
+    orders: List[Order] = []
+    if not tbody:
+        return orders
+    for tr in tbody.find_all("tr"):
+        tds = tr.find_all("td")
+        try:
+            cell_parts = list(tds[0].stripped_strings) if tds else []
+            order_num = ""
+            company = ""
+            for part in cell_parts:
+                if not order_num and re.search(r"\d", part):
+                    match = re.search(r"([A-Za-z0-9_-]+)$", part)
+                    order_num = (
+                        match.group(1) if match else re.sub(r"[^A-Za-z0-9_-]", "", part)
+                    )
+                elif not company and re.search(r"[A-Za-z]", part):
+                    company = part
+            if (not company or company == "?") and len(tds) > 1:
+                for text in tds[1].stripped_strings:
+                    company = text
+                    break
+            status = tds[2].get_text(strip=True) if len(tds) > 2 else ""
+            priority = ""
+            if len(tds) > 4:
+                pri_input = tds[4].find("input")
+                priority = (
+                    pri_input.get("value") if pri_input else tds[4].get_text(strip=True)
+                )
+            steps: List[Step] = []
+            for li in tr.select("ul.workplaces li"):
+                step_p = li.find("p")
+                step_name = (
+                    re.sub(r"^\d+", "", step_p.get_text(strip=True)) if step_p else ""
+                )
+                time_p = li.find("p", class_="np")
+                ts = None
+                if time_p:
+                    text = time_p.get_text(strip=True).replace("\xa0", "").strip()
+                    if text:
+                        try:
+                            ts = datetime.strptime(text, HTML_DATE_FORMAT)
+                        except ValueError:
+                            pass
+                steps.append(Step(step_name, ts))
+            orders.append(Order(order_num, company, status, priority, steps))
+        except Exception:
+            logger.exception("Error parsing row")
+    return orders
+
+
+def parse_queue(html: str) -> Set[str]:
+    """Parse the queue HTML page and return a set of job numbers."""
+    soup = BeautifulSoup(html, "html.parser")
+    tbody = soup.find("tbody")
+    current: Set[str] = set()
+    if not tbody:
+        return current
+    for tr in tbody.find_all("tr"):
+        td_text = tr.get_text(" ", strip=True)
+        match = re.search(r"([A-Za-z0-9_-]*\d+[A-Za-z0-9_-]*)", td_text)
+        if match:
+            current.add(match.group(1))
+    return current

--- a/test_YBS_CONTROL.py
+++ b/test_YBS_CONTROL.py
@@ -124,7 +124,7 @@ class YBSControlTests(unittest.TestCase):
         self.assertTrue(row[1])
 
     def test_process_queue_html_logs_error_on_malformed_html(self):
-        with patch("ui.order_app.BeautifulSoup", side_effect=ValueError("boom")):
+        with patch("ui.order_app.parse_queue", side_effect=ValueError("boom")):
             with self.assertLogs("ui.order_app", level="ERROR") as cm:
                 self.app._process_queue_html("<bad>")
         self.assertTrue(any("Error processing queue HTML" in msg for msg in cm.output))

--- a/test_manage_html_parser.py
+++ b/test_manage_html_parser.py
@@ -1,0 +1,33 @@
+import pytest
+from datetime import datetime
+
+from parsers.manage_html import parse_orders, parse_queue, Order, Step
+
+
+def test_parse_orders_basic():
+    html = (
+        "<table><tbody id='table'>"
+        "<tr>"
+        "<td>ACME Corp<br>Order #12345<ul class='workplaces'>"
+        "<li><p>1Cut</p><p class='np'>01/01/24 10:00</p></li>"
+        "</ul></td>"
+        "<td></td>"
+        "<td>Running</td>"
+        "<td></td>"
+        "<td><input value='High'/></td>"
+        "</tr>"
+        "</tbody></table>"
+    )
+    orders = parse_orders(html)
+    assert len(orders) == 1
+    order = orders[0]
+    assert order.number == "12345"
+    assert order.company == "ACME Corp"
+    assert order.status == "Running"
+    assert order.priority == "High"
+    assert order.steps == [Step(name="Cut", timestamp=datetime(2024, 1, 1, 10, 0))]
+
+
+def test_parse_queue_extracts_orders():
+    html = "<table><tbody><tr><td>Order 100</td></tr><tr><td>Job-200</td></tr></tbody></table>"
+    assert parse_queue(html) == {"100", "Job-200"}


### PR DESCRIPTION
## Summary
- Add `parsers.manage_html` with `parse_orders` and `parse_queue` returning dataclasses
- Update order app to delegate HTML parsing to new helpers
- Cover parsers with unit tests and adjust queue HTML error test

## Testing
- `pytest test_manage_html_parser.py -q`
- `pytest test_YBS_CONTROL.py::YBSControlTests::test_process_queue_html_records_disappearance -q`
- `pytest test_YBS_CONTROL.py::YBSControlTests::test_process_queue_html_logs_error_on_malformed_html -q`
- `pytest test_YBS_CONTROL.py::YBSControlTests::test_parse_company_and_order_from_same_cell -q`


------
https://chatgpt.com/codex/tasks/task_e_689ebc4881a8832da508afdfb277d781