### PR TITLE
Centralize configurable endpoints

### DIFF
--- a/YBS_CONTROL.py
+++ b/YBS_CONTROL.py
@@ -1,11 +1,12 @@
 import customtkinter as ctk
 
 from ui.order_app import OrderScraperApp
+from config.endpoints import LOGIN_URL, ORDERS_URL
 
 
 def main():
     root = ctk.CTk()
-    OrderScraperApp(root)
+    OrderScraperApp(root, login_url=LOGIN_URL, orders_url=ORDERS_URL)
     root.mainloop()
 
 

--- a/config/endpoints.py
+++ b/config/endpoints.py
@@ -1,0 +1,12 @@
+import os
+from .settings import load_config
+
+_DEFAULT_LOGIN_URL = "https://www.ybsnow.com/index.php"
+_DEFAULT_ORDERS_URL = "https://www.ybsnow.com/manage.html"
+_DEFAULT_QUEUE_URL = "https://www.ybsnow.com/queue.html"
+
+_config = load_config()
+
+LOGIN_URL = os.getenv("YBS_LOGIN_URL", _config.get("login_url", _DEFAULT_LOGIN_URL))
+ORDERS_URL = os.getenv("YBS_ORDERS_URL", _config.get("orders_url", _DEFAULT_ORDERS_URL))
+QUEUE_URL = os.getenv("YBS_QUEUE_URL", _config.get("queue_url", _DEFAULT_QUEUE_URL))

--- a/login_dialog.py
+++ b/login_dialog.py
@@ -3,8 +3,7 @@ from tkinter import messagebox
 import requests
 import os
 
-LOGIN_URL = "https://www.ybsnow.com/index.php"
-ORDERS_URL = "https://www.ybsnow.com/manage.html"
+from config.endpoints import LOGIN_URL, ORDERS_URL
 
 
 class LoginDialog(ctk.CTk):

--- a/services/ybs_client.py
+++ b/services/ybs_client.py
@@ -1,9 +1,7 @@
 import os
 import requests
 
-LOGIN_URL = "https://www.ybsnow.com/index.php"
-ORDERS_URL = "https://www.ybsnow.com/manage.html"
-QUEUE_URL = "https://www.ybsnow.com/queue.html"
+from config.endpoints import LOGIN_URL, ORDERS_URL, QUEUE_URL
 
 def login(session, credentials):
     """Attempt to log into YBS.


### PR DESCRIPTION
## Summary
- Add `config/endpoints.py` to centralize endpoint URLs with environment/config overrides
- Use shared endpoint constants in `YBS_CONTROL.py`, `login_dialog.py`, and `services/ybs_client.py`

## Testing
- `pytest test_YBS_CONTROL.py -q`
- `pytest -q` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_689ec6a9c878832d8c215b9db7f4c4c6