### PR TITLE
Add type hints and mypy checks to OrderScraperApp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ matplotlib
 pytest
 requests
 tkcalendar
+mypy

--- a/test_YBS_CONTROL.py
+++ b/test_YBS_CONTROL.py
@@ -6,7 +6,7 @@ import os
 import sqlite3
 import threading
 
-from ui.order_app import OrderScraperApp
+from ui.order_app import OrderScraperApp, OrderRow, JobStep
 from login_dialog import LoginDialog
 from datetime import datetime, time
 import time_utils
@@ -206,7 +206,7 @@ class YBSControlTests(unittest.TestCase):
         self.app.orders_tree.item.return_value = ("123",)
         # steps contain a workstation without a timestamp
         t1 = datetime(2024, 1, 1, 8, 0)
-        self.app.load_steps = MagicMock(return_value=[("Cutting", t1), ("Welding", None)])
+        self.app.load_steps = MagicMock(return_value=[JobStep("Cutting", t1), JobStep("Welding", None)])
         self.app.load_lead_times = MagicMock(return_value=[])
         self.app.report_tree = MagicMock()
         db_cursor = MagicMock()
@@ -270,8 +270,8 @@ class YBSControlTests(unittest.TestCase):
         self.app.analytics_start_var = SimpleVar("")
         self.app.analytics_end_var = SimpleVar("")
         self.app.analytics_job_var = SimpleVar("")
-        self.app.order_rows = [("123", "ACME", "Running", "High")]
-        self.app.load_steps = MagicMock(return_value=[("Cutting", datetime(2024, 1, 1, 8, 0)), ("Welding", datetime(2024, 1, 1, 12, 0))])
+        self.app.order_rows = [OrderRow("123", "ACME", "Running", "High")]
+        self.app.load_steps = MagicMock(return_value=[JobStep("Cutting", datetime(2024, 1, 1, 8, 0)), JobStep("Welding", datetime(2024, 1, 1, 12, 0))])
         mock_compute.return_value = {"123": [{"hours": 4, "workstation": "Welding"}]}
         OrderScraperApp.update_analytics_chart(self.app)
         mock_compute.assert_called_once()

--- a/test_mypy.py
+++ b/test_mypy.py
@@ -1,0 +1,10 @@
+import subprocess
+
+
+def test_mypy() -> None:
+    result = subprocess.run(
+        ["mypy", "--ignore-missing-imports", "--follow-imports=skip", "ui/order_app.py"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- Introduce `JobStep` and `OrderRow` dataclasses and add type annotations across `OrderScraperApp`
- Update tests for new models and add a dedicated mypy test
- Include mypy in requirements and wire it into CI

## Testing
- `mypy --ignore-missing-imports --follow-imports=skip ui/order_app.py`
- `pytest test_mypy.py -q`
- `pytest -k "not test_mypy" -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_689fc16494a0832db5f3abcb6034cae0