### PR TITLE
Fix refresh timer label placement

### DIFF
--- a/ui/order_app.py
+++ b/ui/order_app.py
@@ -148,7 +148,7 @@ class OrderScraperApp:
         self.tab_control.pack(expand=1, fill="both")
 
         self.refresh_timer_label = ctk.CTkLabel(root, textvariable=self.refresh_timer_var)
-        self.refresh_timer_label.place(relx=1.0, rely=1.0, anchor="se", padx=10, pady=5)
+        self.refresh_timer_label.place(relx=1.0, rely=1.0, anchor="se", x=-10, y=-5)
 
         self.analytics_window: Any = None
 


### PR DESCRIPTION
## Summary
- use valid `place` arguments for refresh timer label

## Testing
- `xvfb-run -a python - <<'PY'
import customtkinter as ctk
from ui.order_app import OrderScraperApp
from config.endpoints import LOGIN_URL, ORDERS_URL
root = ctk.CTk()
OrderScraperApp(root, login_url=LOGIN_URL, orders_url=ORDERS_URL)
root.update()
root.destroy()
print('Application instantiated and destroyed')
PY`
- `pytest test_time_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a00161a440832d9eb0b6d310ba8e52