### PR TITLE
Ensure CustomTkinter uses dark theme

### DIFF
--- a/YBS_CONTROL.py
+++ b/YBS_CONTROL.py
@@ -1,5 +1,9 @@
 import customtkinter as ctk
 
+# Configure dark appearance and theme before creating any widgets
+ctk.set_appearance_mode("dark")
+ctk.set_default_color_theme("dark-blue")
+
 from ui.order_app import OrderScraperApp
 from config.endpoints import LOGIN_URL
 

--- a/login_dialog.py
+++ b/login_dialog.py
@@ -3,6 +3,10 @@ from tkinter import messagebox
 import requests
 import os
 
+# Configure dark appearance and theme before creating any widgets
+ctk.set_appearance_mode("dark")
+ctk.set_default_color_theme("dark-blue")
+
 from config.endpoints import LOGIN_URL, ORDERS_URL
 
 


### PR DESCRIPTION
## Summary
- Apply global dark appearance and "dark-blue" theme for CustomTkinter widgets
- Ensure LoginDialog and main app default to dark styling

## Testing
- `python - <<'PY'
import customtkinter as ctk
import YBS_CONTROL
import login_dialog
print('Appearance after importing YBS_CONTROL:', ctk.get_appearance_mode())
print('Appearance after importing login_dialog:', ctk.get_appearance_mode())
PY`
- `pip install tzdata`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a00be114e0832d9d5f4eacee31e1f0