### PR TITLE
Use LoginDialog for startup authentication

### DIFF
--- a/YBS_CONTROL.py
+++ b/YBS_CONTROL.py
@@ -5,12 +5,20 @@ ctk.set_appearance_mode("dark")
 ctk.set_default_color_theme("dark-blue")
 
 from ui.order_app import OrderScraperApp
-from config.endpoints import LOGIN_URL
+from login_dialog import LoginDialog
 
 
 def main():
+    dialog = LoginDialog()
+    dialog.mainloop()
+    if not dialog.authenticated:
+        return
     root = ctk.CTk()
-    OrderScraperApp(root, login_url=LOGIN_URL)
+    OrderScraperApp(
+        root,
+        session=dialog.session,
+        orders_url=dialog.orders_url_var.get(),
+    )
     root.mainloop()
 
 


### PR DESCRIPTION
## Summary
- show a login dialog before launching the main OrderScraperApp
- pass the authenticated session and orders URL to the app
- drop unused login state and re-login thread from OrderScraperApp

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a00cba72d4832d83b83c69c6b8ca4c