### PR TITLE
Make login dialog modal and centralize CustomTkinter theme

### DIFF
--- a/YBS_CONTROL.py
+++ b/YBS_CONTROL.py
@@ -9,11 +9,12 @@ from login_dialog import LoginDialog
 
 
 def main():
-    dialog = LoginDialog()
-    dialog.mainloop()
+    root = ctk.CTk()
+    dialog = LoginDialog(root)
+    dialog.grab_set()
+    root.wait_window(dialog)
     if not dialog.authenticated:
         return
-    root = ctk.CTk()
     OrderScraperApp(
         root,
         session=dialog.session,

--- a/login_dialog.py
+++ b/login_dialog.py
@@ -3,16 +3,12 @@ from tkinter import messagebox
 import requests
 import os
 
-# Configure dark appearance and theme before creating any widgets
-ctk.set_appearance_mode("dark")
-ctk.set_default_color_theme("dark-blue")
-
 from config.endpoints import LOGIN_URL, ORDERS_URL
 
 
-class LoginDialog(ctk.CTk):
-    def __init__(self):
-        super().__init__()
+class LoginDialog(ctk.CTkToplevel):
+    def __init__(self, parent):
+        super().__init__(parent)
         self.title("Login")
         self.session = requests.Session()
         self.authenticated = False


### PR DESCRIPTION
## Summary
- Convert `LoginDialog` to a `CTkToplevel` that accepts a parent window
- Instantiate the dialog from `YBS_CONTROL` with `grab_set` for modal behaviour
- Keep CustomTkinter theme configuration only in `YBS_CONTROL`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a02430fec4832d9b9a329f79f4cb3a