### PR TITLE
Simplify login dialog and use static endpoints

### DIFF
--- a/login_dialog.py
+++ b/login_dialog.py
@@ -9,37 +9,30 @@ from config.endpoints import LOGIN_URL, ORDERS_URL
 class LoginDialog(ctk.CTkToplevel):
     def __init__(self, parent):
         super().__init__(parent)
-        self.title("Login")
+        self.title("Login for YBSnow.com")
         self.session = requests.Session()
         self.authenticated = False
 
         self.username_var = ctk.StringVar()
         self.password_var = ctk.StringVar()
-        self.login_url_var = ctk.StringVar()
-        self.orders_url_var = ctk.StringVar()
-
+        ctk.CTkLabel(self, text="USER").grid(
+            row=0, column=0, columnspan=2, padx=5, pady=(5, 0)
+        )
         ctk.CTkEntry(
             self,
             textvariable=self.username_var,
-            placeholder_text="Username",
-        ).grid(row=0, column=0, columnspan=2, padx=5, pady=5)
+        ).grid(row=1, column=0, columnspan=2, padx=5, pady=(0, 5))
+        ctk.CTkLabel(self, text="PASSWORD").grid(
+            row=2, column=0, columnspan=2, padx=5, pady=(5, 0)
+        )
         ctk.CTkEntry(
             self,
             textvariable=self.password_var,
             show="*",
-            placeholder_text="Password",
-        ).grid(row=1, column=0, columnspan=2, padx=5, pady=5)
-        ctk.CTkEntry(
-            self,
-            textvariable=self.login_url_var,
-            placeholder_text="Login URL",
-        ).grid(row=2, column=0, columnspan=2, padx=5, pady=5)
-        ctk.CTkEntry(
-            self,
-            textvariable=self.orders_url_var,
-            placeholder_text="Orders URL",
-        ).grid(row=3, column=0, columnspan=2, padx=5, pady=5)
-        ctk.CTkButton(self, text="Login", command=self.login).grid(row=4, column=0, columnspan=2, pady=10)
+        ).grid(row=3, column=0, columnspan=2, padx=5, pady=(0, 5))
+        ctk.CTkButton(self, text="Login", command=self.login).grid(
+            row=4, column=0, columnspan=2, pady=10
+        )
 
     def login(self, silent=False):
         username = self.username_var.get().strip()
@@ -53,14 +46,13 @@ class LoginDialog(ctk.CTkToplevel):
             "password": password,
             "action": "signin",
         }
-        login_url = self.login_url_var.get() or LOGIN_URL
         try:
-            resp = self.session.post(login_url, data=data, timeout=10)
+            resp = self.session.post(LOGIN_URL, data=data, timeout=10)
         except requests.RequestException as e:
             if not silent:
                 messagebox.showerror("Login", f"Login request failed: {e}")
             return
-        orders_page = os.path.basename(self.orders_url_var.get() or ORDERS_URL).lower()
+        orders_page = os.path.basename(ORDERS_URL).lower()
         if "logout" in resp.text.lower() or orders_page in resp.text.lower():
             self.authenticated = True
             if not silent:

--- a/test_YBS_CONTROL.py
+++ b/test_YBS_CONTROL.py
@@ -27,13 +27,12 @@ class LoginDialogTests(unittest.TestCase):
         self.dialog.session = MagicMock()
         self.dialog.username_var = SimpleVar("user")
         self.dialog.password_var = SimpleVar("pass")
-        self.dialog.login_url_var = SimpleVar("http://example.com/login")
-        self.dialog.orders_url_var = SimpleVar("http://example.com/orders")
 
     @patch("login_dialog.messagebox")
     def test_login_request_exception(self, mock_messagebox):
         self.dialog.session.post.side_effect = requests.Timeout("boom")
-        self.dialog.login()
+        with patch("login_dialog.LOGIN_URL", "http://example.com/login"):
+            self.dialog.login()
         self.dialog.session.post.assert_called_with(
             "http://example.com/login",
             data={"email": "user", "password": "pass", "action": "signin"},

--- a/test_generate_production_report.py
+++ b/test_generate_production_report.py
@@ -41,7 +41,7 @@ def test_timezone_conversion_and_storage():
         events,
         "2024-01-01T00:00:00Z",
         "2024-01-02T00:00:00Z",
-        tz="US/Eastern",
+        tz="America/New_York",
     )
 
     assert report["details"][0]["start"].startswith("2024-01-01T00:00:00+00:00")


### PR DESCRIPTION
## Summary
- streamline login dialog with dedicated USER and PASSWORD fields
- post directly to configured LOGIN_URL and validate with ORDERS_URL

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a02d4e9f9c832d81d817a8e6046d76