### PR TITLE
Handle missing orders URL in main

### DIFF
--- a/YBS_CONTROL.py
+++ b/YBS_CONTROL.py
@@ -6,6 +6,7 @@ ctk.set_default_color_theme("dark-blue")
 
 from ui.order_app import OrderScraperApp
 from login_dialog import LoginDialog
+from config.endpoints import ORDERS_URL
 
 
 def main():
@@ -14,10 +15,16 @@ def main():
     if not dialog.authenticated:
         return
     root = ctk.CTk()
+    orders_var = getattr(dialog, "orders_url_var", None)
+    orders_url = ORDERS_URL
+    if orders_var:
+        value = orders_var.get()
+        if value:
+            orders_url = value
     OrderScraperApp(
         root,
         session=dialog.session,
-        orders_url=dialog.orders_url_var.get(),
+        orders_url=orders_url,
     )
     root.mainloop()
 


### PR DESCRIPTION
## Summary
- Default OrderScraperApp orders_url to ORDERS_URL when login dialog doesn't provide one

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a030de0038832d93f3b00dc564e029